### PR TITLE
feat: add mind-nvim to note-taking plugins

### DIFF
--- a/extra.nix
+++ b/extra.nix
@@ -136,7 +136,8 @@ inputs: let
 
       vim.notes = {
         obsidian.enable = false; # FIXME neovim fails to build if obsidian is enabled
-        orgmode.enable = true;
+        orgmode.enable = false;
+        mind-nvim.enable = true;
       };
 
       vim.terminal = {

--- a/flake.lock
+++ b/flake.lock
@@ -514,6 +514,22 @@
         "type": "github"
       }
     },
+    "mind-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1674572816,
+        "narHash": "sha256-yLf/2NvPT0RtFh6+0W32Uaj3Tjs52oyZSb8Jq3INZI4=",
+        "owner": "phaazon",
+        "repo": "mind.nvim",
+        "rev": "e59c52758c399caceb549c698cfa2d65e6bbb9f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phaazon",
+        "repo": "mind.nvim",
+        "type": "github"
+      }
+    },
     "minimap-vim": {
       "flake": false,
       "locked": {
@@ -1079,6 +1095,7 @@
         "lspkind": "lspkind",
         "lspsaga": "lspsaga",
         "lualine": "lualine",
+        "mind-nvim": "mind-nvim",
         "minimap-vim": "minimap-vim",
         "nil": "nil",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -361,6 +361,11 @@
       flake = false;
     };
 
+    mind-nvim = {
+      url = "github:phaazon/mind.nvim";
+      flake = false;
+    };
+
     # Terminal
     toggleterm-nvim = {
       url = "github:akinsho/toggleterm.nvim";

--- a/lib/types-plugin.nix
+++ b/lib/types-plugin.nix
@@ -68,6 +68,7 @@ with lib; let
     "gesture-nvim"
     "comment-nvim"
     "kommentary"
+    "mind-nvim"
   ];
   # You can either use the name of the plugin or a package.
   pluginsType = with types; listOf (nullOr (either (enum availablePlugins) package));

--- a/modules/notes/default.nix
+++ b/modules/notes/default.nix
@@ -2,5 +2,6 @@ _: {
   imports = [
     ./obsidian
     ./orgmode
+    ./mind-nvim
   ];
 }

--- a/modules/notes/mind-nvim/default.nix
+++ b/modules/notes/mind-nvim/default.nix
@@ -1,0 +1,30 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.notes.mind-nvim;
+in {
+  options.vim.notes.mind-nvim = {
+    enable = mkEnableOption "The power of trees at your fingertips. ";
+  };
+
+  config = mkIf (cfg.enable) {
+    vim.startPlugins = [
+      "mind-nvim"
+    ];
+
+    vim.nnoremap = {
+      "<C-o-m>" = ":MindOpenMain<CR>";
+      "<C-o-p" = ":MindOpenProject<CR>";
+      "<leader>mc" = ":MindClose<CR>";
+    };
+
+    vim.luaConfigRC.mind-nvim = nvim.dag.entryAnywhere ''
+      require'mind'.setup()
+    '';
+  };
+}

--- a/modules/notes/mind-nvim/default.nix
+++ b/modules/notes/mind-nvim/default.nix
@@ -18,9 +18,9 @@ in {
     ];
 
     vim.nnoremap = {
-      "<C-o-m>" = ":MindOpenMain<CR>";
-      "<C-o-p" = ":MindOpenProject<CR>";
-      "<leader>mc" = ":MindClose<CR>";
+      "<leader>om" = ":MindOpenMain<CR>";
+      "<leader>op" = ":MindOpenProject<CR>";
+      "<leader>oc" = ":MindClose<CR>";
     };
 
     vim.luaConfigRC.mind-nvim = nvim.dag.entryAnywhere ''


### PR DESCRIPTION
Implements the [mind.nvim](https://github.com/phaazon/mind.nvim) plugin and disables orgmode by default.

Closes #6 