### PR TITLE
Feature/barbecue.nvim

### DIFF
--- a/extra.nix
+++ b/extra.nix
@@ -65,6 +65,10 @@ inputs: let
         theme = "catppuccin";
       };
 
+      vim.winbar = {
+        barbecue.enable = true;
+      };
+
       vim.theme = {
         enable = true;
         name = "catppuccin";

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "barbecue-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1677143543,
+        "narHash": "sha256-+zg1Zx6L0ii/8LobalGWtVu0/FoazDKBRgJ3PwLol1M=",
+        "owner": "utilyre",
+        "repo": "barbecue.nvim",
+        "rev": "23348f3979912fb36a1442fb0d07e8d2e739aea2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "utilyre",
+        "repo": "barbecue.nvim",
+        "type": "github"
+      }
+    },
     "bufdelete-nvim": {
       "flake": false,
       "locked": {
@@ -834,6 +850,22 @@
         "type": "github"
       }
     },
+    "nvim-navic": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675527008,
+        "narHash": "sha256-VUDlx2V9r5X5tidVXHpNiRWfvtVRsG/H38wmAVfRvwk=",
+        "owner": "SmiteshP",
+        "repo": "nvim-navic",
+        "rev": "7e9d2b2b601149fecdccd11b516acb721e571fe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SmiteshP",
+        "repo": "nvim-navic",
+        "type": "github"
+      }
+    },
     "nvim-neoclip": {
       "flake": false,
       "locked": {
@@ -1065,6 +1097,7 @@
     "root": {
       "inputs": {
         "alpha-nvim": "alpha-nvim",
+        "barbecue-nvim": "barbecue-nvim",
         "bufdelete-nvim": "bufdelete-nvim",
         "catppuccin": "catppuccin",
         "cellular-automaton": "cellular-automaton",
@@ -1110,6 +1143,7 @@
         "nvim-cursorline": "nvim-cursorline",
         "nvim-lightbulb": "nvim-lightbulb",
         "nvim-lspconfig": "nvim-lspconfig",
+        "nvim-navic": "nvim-navic",
         "nvim-neoclip": "nvim-neoclip",
         "nvim-notify": "nvim-notify",
         "nvim-session-manager": "nvim-session-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,17 @@
       flake = false;
     };
 
+    # Winbar
+    nvim-navic = {
+      url = "github:SmiteshP/nvim-navic";
+      flake = false;
+    };
+
+    barbecue-nvim = {
+      url = "github:utilyre/barbecue.nvim";
+      flake = false;
+    };
+
     # Statuslines
     lualine = {
       url = "github:hoob3rt/lualine.nvim";

--- a/lib/types-plugin.nix
+++ b/lib/types-plugin.nix
@@ -69,6 +69,8 @@ with lib; let
     "comment-nvim"
     "kommentary"
     "mind-nvim"
+    "nvim-navic"
+    "barbecue-nvim"
   ];
   # You can either use the name of the plugin or a package.
   pluginsType = with types; listOf (nullOr (either (enum availablePlugins) package));

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -30,6 +30,7 @@
     ./assistant
     ./session
     ./comments
+    ./winbar
   ];
 
   pkgsModule = {config, ...}: {

--- a/modules/winbar/barbecue/default.nix
+++ b/modules/winbar/barbecue/default.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.winbar.barbecue;
+in {
+  options.vim.winbar.barbecue = {
+    enable = mkEnableOption "Enable barbecue.nvim";
+  };
+
+  config = (mkIf cfg.enable) {
+    vim.startPlugins =
+      [
+        "barbecue-nvim"
+        "nvim-navic"
+      ]
+      ++ optional (config.vim.visuals.nvimWebDevicons.enable) "nvim-web-devicons";
+
+    vim.luaConfigRC.barbecue-nvim = nvim.dag.entryAnywhere ''
+      config = function()
+        require("barbecue").setup()
+      end,
+    '';
+  };
+}

--- a/modules/winbar/barbecue/default.nix
+++ b/modules/winbar/barbecue/default.nix
@@ -25,5 +25,17 @@ in {
         require("barbecue").setup()
       end,
     '';
+
+    vim.luaConfigRC.nvim-navic = nvim.dag.entryAnywhere ''
+
+      local navic = require("nvim-navic")
+
+      require("lspconfig").clangd.setup {
+        on_attach = function(client, bufnr)
+          navic.attach(client, bufnr)
+        end
+      }
+
+    '';
   };
 }

--- a/modules/winbar/default.nix
+++ b/modules/winbar/default.nix
@@ -1,0 +1,5 @@
+_: {
+  imports = [
+    ./barbecue
+  ];
+}


### PR DESCRIPTION
This adds [barbecue.nvim](https://github.com/utilyre/barbecue.nvim) alongside [nvim-navic](https://github.com/SmiteshP/nvim-navic)

Currently `Barbecue`, probably alongside `nvim-navic` fail to load for a reason that I cannot figure out. Any help is appreciated. The config for both of those plugins will be in `modules/winbar/barbecue/default.nix`