### PR TITLE
Change hm-module to default as can be found in the code

### DIFF
--- a/docs/home-manager.adoc
+++ b/docs/home-manager.adoc
@@ -19,7 +19,7 @@ Followed by importing the HM module.
 [source,nix]
 ----
 {
-  imports = [ neovim-flake.nixosModules.hm-module ];
+  imports = [ neovim-flake.nixosModules.default ];
 }
 ----
 


### PR DESCRIPTION
# Description

With recent changes, the import was made that way : 
```nix
    imports = [ neovim-flake.nixosModules.default ];
 ```

instead of the former :
```nix
    imports = [ neovim-flake.nixosModules.hm-module ];
```


## Type of change
- Docs

## Checklist
- [x] My code follows the style and contributing guidelines of this project.
- [x] I have performed a self-review of my own code and tested it.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] This change requires a documentation update.
- [x] I have updated the documentation accordingly.