### PR TITLE
Fix home manager module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
 
         homeManagerModules.default = {
           imports = [
-            (import ./lib/module self.packages)
+            (import ./lib/module self.packages inputs)
           ];
         };
       };

--- a/lib/module/default.nix
+++ b/lib/module/default.nix
@@ -1,5 +1,5 @@
 # Home Manager module
-packages: {
+packages: inputs: {
   pkgs,
   config,
   lib ? pkgs.lib,
@@ -8,7 +8,11 @@ packages: {
 }:
 with lib; let
   cfg = config.programs.neovim-flake;
-  set = packages.${pkgs.system}.maximal.override {mainConfig = cfg.settings;};
+  inherit (import ../../extra.nix inputs) neovimConfiguration;
+  set = neovimConfiguration {
+    inherit pkgs;
+    modules = [cfg.settings];
+  };
 in {
   meta.maintainers = [maintainers.notashelf];
 


### PR DESCRIPTION
From what I understand, the problem is that you can't override sets made with `neovimConfiguration`.

My solution was to get `neovimConfiguration` to `lib/module/default.nix` and just build a new package.
I did it by passing inputs to `lib/module/default.nix`, you might not want to do that, IDK.
I couldn't figure out how to add the default overlay (which contains `neovimConfiguration`) to the home manager module's pkgs (never worked with one). So i just passed inputs and got `neovimConfiguration` with that.

might also be a good idea to call it `mkNeovimConfiguration` instead?