### PR TITLE
Dart fixes

### DIFF
--- a/modules/languages/dart/config.nix
+++ b/modules/languages/dart/config.nix
@@ -12,7 +12,7 @@ with builtins; let
     dart = {
       package = pkgs.dart;
       lspConfig = ''
-        lspconfig.dart.setup{
+        lspconfig.dartls.setup{
           capabilities = capabilities;
           on_attach=default_on_attach;
           cmd = {"${pkgs.dart}/bin/dart"};

--- a/modules/languages/dart/config.nix
+++ b/modules/languages/dart/config.nix
@@ -15,7 +15,7 @@ with builtins; let
         lspconfig.dartls.setup{
           capabilities = capabilities;
           on_attach=default_on_attach;
-          cmd = {"${pkgs.dart}/bin/dart"};
+          cmd = {"${pkgs.dart}/bin/dart", "language-server", "--protocol=lsp"};
           ${optionalString (cfg.lsp.opts != null) "init_options = ${cfg.lsp.dartOpts}"}
         }
       '';

--- a/modules/languages/dart/dart.nix
+++ b/modules/languages/dart/dart.nix
@@ -12,7 +12,7 @@ with builtins; let
     dart = {
       package = pkgs.dart;
       lspConfig = ''
-        lspconfig.dart.setup{
+        lspconfig.dartls.setup{
           capabilities = capabilities;
           on_attach=default_on_attach;
           cmd = {"${pkgs.dart}/bin/dart"};

--- a/modules/languages/dart/dart.nix
+++ b/modules/languages/dart/dart.nix
@@ -15,7 +15,7 @@ with builtins; let
         lspconfig.dartls.setup{
           capabilities = capabilities;
           on_attach=default_on_attach;
-          cmd = {"${pkgs.dart}/bin/dart"};
+          cmd = {"${pkgs.dart}/bin/dart", "language-server", "--protocol=lsp"};
           ${optionalString (cfg.lsp.opts != null) "init_options = ${cfg.lsp.dartOpts}"}
         }
       '';

--- a/modules/languages/dart/dart.nix
+++ b/modules/languages/dart/dart.nix
@@ -35,11 +35,7 @@ in {
     };
 
     lsp = {
-      enable = mkOption {
-        description = "Enable Dart LSP support";
-        type = types.bool;
-        default = config.vim.languages.enableLSP;
-      };
+      enable = mkEnableOption "Enable Dart LSP support";
       server = mkOption {
         description = "The Dart LSP server to use";
         type = with types; enum (attrNames servers);
@@ -58,7 +54,11 @@ in {
     };
 
     flutter-tools = {
-      enable = mkEnableOption "Enable flutter-tools for flutter support";
+      enable = mkOption {
+        description = "Enable flutter-tools for flutter support";
+        type = types.bool;
+        default = config.vim.languages.enableLSP;
+      };
 
       color = {
         enable = mkEnableOption "Whether or mot to highlight color variables at all";


### PR DESCRIPTION
fixes some things(see commits) with the Dart lsp to make it work.

- I tried to add an assert that prohibits dart.lsp.enable and dart.flutter-tools.enable to be both enabled, but i have no idea how to do it with nix's module system.

- I also changed the default from dart.lsp.enable to dart.flutter-tools.enable. The reason behind it is that flutter-tools is compatible with both dart and flutter lsps, while dart.lsp is not compatible with flutter. But I had noticed that flutter-tools requires dart(or flutter) to be in path while running nvim, while dart.lsp doesn't. So I can drop the commit if you want dart.lsp to be the default.