### PR TITLE
Update tokyonight config

### DIFF
--- a/docs/release-notes/rl-0.3.adoc
+++ b/docs/release-notes/rl-0.3.adoc
@@ -15,3 +15,5 @@
 * Improved handling of completion formatting. When setting <<opt-vim.autocomplete.sources>>, can also include optional menu mapping. And can provide your own function with <<opt-vim.autocomplete.formatting.format>>.
 
 * For <<opt-vim.visuals.indentBlankline.fillChar>> and <<opt-vim.visuals.indentBlankline.eolChar>> turning them off should use `null` rather than `""` now.
+
+* Fixed deprecated configuration method for Tokyonight, and added new style "moon"

--- a/modules/theme/supported_themes.nix
+++ b/modules/theme/supported_themes.nix
@@ -14,7 +14,7 @@
     setup = {style ? "night"}: ''
       vim.cmd[[colorscheme tokyonight-${style}]]
     '';
-    styles = ["day" "night" "storm"];
+    styles = ["day" "night" "storm" "moon"];
   };
 
   dracula = {

--- a/modules/theme/supported_themes.nix
+++ b/modules/theme/supported_themes.nix
@@ -12,9 +12,7 @@
 
   tokyonight = {
     setup = {style ? "night"}: ''
-      -- need to set style before colorscheme to apply
-      vim.g.tokyonight_style = '${style}'
-      vim.cmd[[colorscheme tokyonight]]
+      vim.cmd[[colorscheme tokyonight-${style}]]
     '';
     styles = ["day" "night" "storm"];
   };


### PR DESCRIPTION
the `vim.g.tokyonight_style` seems to be deprecated and does nothing

also added new style "moon"

from `:help tokyonight.nvim-tokyo-night-usage`:

```
    colorscheme tokyonight
    
    " There are also colorschemes for the different styles
    colorscheme tokyonight-night
    colorscheme tokyonight-storm
    colorscheme tokyonight-day
    colorscheme tokyonight-moon

```