### PR TITLE
0.3 release

### DIFF
--- a/docs/release-notes/rl-0.3.adoc
+++ b/docs/release-notes/rl-0.3.adoc
@@ -1,3 +1,35 @@
+[[sec-release-0.3]]
+== Release 0.3
+
+Release 0.3 had to come out beore I wanted it to due to Neovim 0.9 dropping into nixpkgs-unstable. The treesitter changes
+have prompted a treesitter rework, which was followed by reworking the languages system. Most of the changes to those are downstreamed
+from the original repository. The feature requests that was originally planned for 0.3 have been moved to 0.4, which 
+should come out soon.
+
+[[sec-release-0.3-changelog]]
+=== Changelog
+
+* We have transitioned to flake-parts, from flake-utils to extend the flexibility of this flake. This means the flake structure 
+is different than usual, but the functionality remains the same.
+
+* We now provide a home-manager module. Do note that it is still far from perfect, but it works.
+
+* `nodejs_16` is now bundled with `Copilot.lua` if the user has enabled Copilot assistant.
+
+* which-key section titles have been fixed. This is to be changed once again in a possible keybind rewrite, but now it should
+display the correct titles instad of `+prefix`
+
+* Most of `presence.nvim`'s options have been made fully configurable through your configuration file.
+
+* Most of the modules have been refactored to separate `config` and `options` attributes.
+
+* Darwin has been deprecated as the zig package is marked as broken. We will attempt to use the zig overlay to return Darwin
+support. 
+
+* `Fidget.nvim` has been added as a neat visual addition for LSP installations.
+
+* `diffview.nvim` has been added to provide a convenient diff utility.
+
 * Treesitter grammars are now configurable with <<opt-vim.treesitter.grammars>>. Utilizes the nixpkgs `nvim-treesitter` plugin rather than a custom input in order to take advantage of build support of pinned versions. See https://discourse.nixos.org/t/psa-if-you-are-on-unstable-try-out-nvim-treesitter-withallgrammars/23321?u=snowytrees[discourse] for more information. Packages can be found under the `pkgs.vimPlugins.nvim-treesitter.builtGrammars` attribute. Treesitter grammars for supported languages should be enabled within the module. By default no grammars are installed, thus the following grammars which do not have a language section are not included anymore: comment, toml, make, html, css, graphql, json.
 
 * A new section has been added for language support: `vim.languages.<language>`. The options <<opt-vim.languages.enableLSP>>, <<opt-vim.languages.enableTreesitter>>, etc. will enable the respective section for all languages that have been enabled.
@@ -9,11 +41,35 @@
 
 * Removed the plugins document in the docs. Was too unwieldy to keep updated.
 
-
 * `vim.visual.lspkind` has been moved to <<opt-vim.lsp.lspkind.enable>>
 
 * Improved handling of completion formatting. When setting <<opt-vim.autocomplete.sources>>, can also include optional menu mapping. And can provide your own function with <<opt-vim.autocomplete.formatting.format>>.
 
 * For <<opt-vim.visuals.indentBlankline.fillChar>> and <<opt-vim.visuals.indentBlankline.eolChar>> turning them off should use `null` rather than `""` now.
 
+* Transparency has been made optional and has been disabled by default. <<opt-vim.theme.transarent>> option can be used to enable or 
+disable transparency for your configuration.
+
 * Fixed deprecated configuration method for Tokyonight, and added new style "moon"
+
+* Dart language support as well as extended flutter support has been added. Thanks to @FlafyDev for his contributions towards Dart 
+language support.
+
+* Elixir language support has been added through `elixir-tools.nvim`.
+
+* `hop.nvim` and `leap.nvim` have been added for fast navigation.
+
+* `modes.nvim` has been added to the UI plugins as a minor error highlighter.
+
+* `smartcollumn.nvim` has been added to dynamically display a colorcolumn when the limit has been exceeded, providing 
+per-buftype column position and more.
+
+* `project.nvim` has been added for better project management inside Neovim.
+
+* More configuration options have been added to `nvim-session-manager`.
+
+* Editorconfig support has been added to the core functionality, with an enable option.
+
+* `venn-nvim` has been dropped due to broken keybinds.
+
+


### PR DESCRIPTION
After a long time, we are ready for the 0.3 release that had to be released earlier than it was meant to be, thanks to an unexpected Neovim 0.9 release. While this release brings a lot of new functionality and changes to the table, the main reason it is being released is to provide Neovim 0.9 support in the latest release for those who may be using stable releases instead of following git closely. Rest of the feature additions will be moved to the 0.4 release, which should be concluded with a breaking keybind rewrite alongside meany feature additions.

This release, of course, is vastly breaking. Most of the language options have been relocated to a new languages attribute inside the config. Caution is advised before switching.

- [x] Docs have been updated
- [x] CI checks pass