### PR TITLE
fix editorconfig option

### DIFF
--- a/modules/basic/config.nix
+++ b/modules/basic/config.nix
@@ -103,8 +103,8 @@ in {
         set termguicolors
         set t_Co=256
       ''}
-      ${optionalString cfg.enableEditorconfig ''
-        vim.g.editorconfig = false
+      ${optionalString (!cfg.enableEditorconfig) ''
+        let g:editorconfig = v:false
       ''}
     '';
   };

--- a/modules/basic/module.nix
+++ b/modules/basic/module.nix
@@ -141,7 +141,7 @@ with builtins; {
     };
     enableEditorconfig = mkOption {
       type = types.bool;
-      default = false;
+      default = true;
       description = "Follow editorconfig rules in current directory";
     };
   };


### PR DESCRIPTION
the config string is written as lua instead of vimscript, and the logic is wrong anyways.

Changed the default to true because that's what neovim ships with, I could change it back if you want