### PR TITLE
fix: ccls config

### DIFF
--- a/modules/languages/clang.nix
+++ b/modules/languages/clang.nix
@@ -16,8 +16,8 @@ with builtins; let
         lspconfig.ccls.setup{
           capabilities = capabilities;
           on_attach=default_on_attach;
-          cmd = {"${pkgs.ccls}/bin/ccls"};
-          ${optionalString (cfg.lsp.opts != null) "init_options = ${cfg.lsp.cclsOpts}"}
+          cmd = {"${cfg.lsp.package}/bin/ccls"};
+          ${optionalString (cfg.lsp.opts != null) "init_options = ${cfg.lsp.opts}"}
         }
       '';
     };


### PR DESCRIPTION
ccls was not using the package defined in `cfg.lsp.package`

and also was using  `cfg.lsp.cclsOpts` which doesn't exist