### PR TITLE
fix: broken python lsp option

### DIFF
--- a/modules/languages/python.nix
+++ b/modules/languages/python.nix
@@ -64,7 +64,11 @@ in {
         type = with types; enum (attrNames servers);
         default = defaultServer;
       };
-      package = nvim.types.mkGrammarOption pkgs "python";
+      package = mkOption {
+        description = "python LSP server package";
+        type = types.package;
+        default = servers.${cfg.lsp.server}.package;
+      };
     };
 
     format = {


### PR DESCRIPTION
python lsp option is written like as treesitter grammar