### PR TITLE
chore: upload docs build artifacts

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -40,5 +40,10 @@ jobs:
         run: nix flake check
       - name: Build neovim-flake with default settings
         run: nix build .#${{ matrix.package }} --print-build-logs
+      - name: Upload doc artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: doc
+          path: result/share/doc/neovim-flake/
      
 


### PR DESCRIPTION
This adds built docs available as .zip downloads for PRs and commits on the main branch, for easier checking when Nix(OS) isn't available.