### PR TITLE
feat: new option to enable lua module loader

### DIFF
--- a/modules/basic/module.nix
+++ b/modules/basic/module.nix
@@ -144,5 +144,7 @@ with builtins; {
       default = true;
       description = "Follow editorconfig rules in current directory";
     };
+
+    enableLuaLoader = mkEnableOption "Enable the experimental Lua module loader to speed up the start up process";
   };
 }

--- a/modules/core/default.nix
+++ b/modules/core/default.nix
@@ -9,6 +9,9 @@ with builtins; let
 
   wrapLuaConfig = luaConfig: ''
     lua << EOF
+    ${optionalString cfg.enableLuaLoader ''
+      vim.loader.enable()
+    ''}
     ${luaConfig}
     EOF
   '';


### PR DESCRIPTION
Enables the experimental lua loader in nvim 0.9, which caches modules like [impatient.nvim](https://github.com/lewis6991/impatient.nvim)

speeds up startup time quite a bit, for me it went from 300~500 ms down to 200 ms, tested with `nvim --startuptime`