### PR TITLE
feature: DAP support

### DIFF
--- a/docs/release-notes/rl-0.4.adoc
+++ b/docs/release-notes/rl-0.4.adoc
@@ -1,6 +1,5 @@
 [[sec-release-0.4]]
 == Release 0.4
-
 Following the release of v0.3, I have decided to release v0.4 with a massive new change: customizable keybinds. As of the 0.4 release, keybinds will no longer be hardcoded and instead provided by each module's own keybinds section. The old keybind system (`vim.keybinds = {}`) is now considered deprecated and the new lib functions are recommended to be used for adding keybinds for new plugins, or adding keybinds to existing plugins.
 
 Alongside customizable keybinds, there are a few quality of life updates, such as `lazygit` integration and the new experimental Lua loader of Neovim 0.9 thanks to our awesome contributors who made this update possible during my absence.
@@ -33,6 +32,8 @@ https://github.com/horriblename[horriblename]:
 * Added `toggleterm` integration for `lazygit`.
 
 * Added new option `enableluaLoader` to enable neovim's experimental module loader for faster startup time.
+
+* Fixed bug where flutter-tools can't find `dart` LSP
 
 https://github.com/notashelf[notashelf]:
 

--- a/docs/release-notes/rl-0.4.adoc
+++ b/docs/release-notes/rl-0.4.adoc
@@ -35,6 +35,8 @@ https://github.com/horriblename[horriblename]:
 
 * Fixed bug where flutter-tools can't find `dart` LSP
 
+* Added Debug Adapter (DAP) support for clang, rust, go, python and dart.
+
 https://github.com/notashelf[notashelf]:
 
 * Made Copilot's Node package configurable. It is recommended to keep as default, but providing a different NodeJS version is now possible.

--- a/extra.nix
+++ b/extra.nix
@@ -39,6 +39,13 @@ inputs: let
         lspSignature.enable = true;
       };
 
+      vim.debugger = {
+        nvim-dap = {
+          enable = true;
+          ui.enable = true;
+        };
+      };
+
       vim.languages = {
         enableLSP = true;
         enableFormat = true;
@@ -217,6 +224,7 @@ inputs: let
           image_text = "The Superior Text Editor";
           client_id = "793271441293967371";
           main_image = "neovim";
+          show_time = true;
           rich_presence = {
             editing_text = "Editing %s";
           };

--- a/flake.lock
+++ b/flake.lock
@@ -1012,6 +1012,38 @@
         "type": "github"
       }
     },
+    "nvim-dap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682077642,
+        "narHash": "sha256-l5sJ6PKW10CtOzSBKzWasWVMZq/mAkgpgWOecIVuV+0=",
+        "owner": "mfussenegger",
+        "repo": "nvim-dap",
+        "rev": "6cedcb527e264c8f25e86afa8dae74c6692dee51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mfussenegger",
+        "repo": "nvim-dap",
+        "type": "github"
+      }
+    },
+    "nvim-dap-ui": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683055722,
+        "narHash": "sha256-8TavZqkTCr2/jaO3C8fp+r7qfN6mCzVvidbHGtJGLfs=",
+        "owner": "rcarriga",
+        "repo": "nvim-dap-ui",
+        "rev": "749bfe12d1447703899fa823c1c075fbe2d42c24",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rcarriga",
+        "repo": "nvim-dap-ui",
+        "type": "github"
+      }
+    },
     "nvim-lightbulb": {
       "flake": false,
       "locked": {
@@ -1360,6 +1392,8 @@
         "nvim-colorizer-lua": "nvim-colorizer-lua",
         "nvim-compe": "nvim-compe",
         "nvim-cursorline": "nvim-cursorline",
+        "nvim-dap": "nvim-dap",
+        "nvim-dap-ui": "nvim-dap-ui",
         "nvim-lightbulb": "nvim-lightbulb",
         "nvim-lspconfig": "nvim-lspconfig",
         "nvim-neoclip": "nvim-neoclip",

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,17 @@
       inputs.flake-utils.follows = "flake-utils";
     };
 
+    # Debuggers
+    nvim-dap = {
+      url = "github:mfussenegger/nvim-dap";
+      flake = false;
+    };
+
+    nvim-dap-ui = {
+      url = "github:rcarriga/nvim-dap-ui";
+      flake = false;
+    };
+
     # Filetrees
     nvim-tree-lua = {
       url = "github:nvim-tree/nvim-tree.lua";

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -73,6 +73,7 @@ with lib; let
     "diffview-nvim"
     "todo-comments"
     "flutter-tools"
+    "flutter-tools-patched"
     "hop-nvim"
     "leap-nvim"
     "modes-nvim"

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -85,6 +85,8 @@ with lib; let
     "nvim-colorizer-lua"
     "vim-illuminate"
     "nvim-surround"
+    "nvim-dap"
+    "nvim-dap-ui"
   ];
   # You can either use the name of the plugin or a package.
   pluginsType = with types;

--- a/modules/debugger/default.nix
+++ b/modules/debugger/default.nix
@@ -1,0 +1,5 @@
+_: {
+  imports = [
+    ./nvim-dap
+  ];
+}

--- a/modules/debugger/nvim-dap/config.nix
+++ b/modules/debugger/nvim-dap/config.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.debugger.nvim-dap;
+in {
+  config = mkIf cfg.enable {
+    vim.startPlugins =
+      [
+        "nvim-dap"
+      ]
+      ++ optionals cfg.ui.enable [
+        "nvim-dap-ui"
+      ];
+
+    vim.luaConfigRC.nvim-dap-ui = nvim.dag.entryAnywhere ''
+      require("dapui").setup()
+    '';
+  };
+}

--- a/modules/debugger/nvim-dap/config.nix
+++ b/modules/debugger/nvim-dap/config.nix
@@ -7,17 +7,32 @@ with lib;
 with builtins; let
   cfg = config.vim.debugger.nvim-dap;
 in {
-  config = mkIf cfg.enable {
-    vim.startPlugins =
-      [
-        "nvim-dap"
-      ]
-      ++ optionals cfg.ui.enable [
-        "nvim-dap-ui"
-      ];
+  config = mkMerge [
+    (mkIf cfg.enable {
+      vim.startPlugins = ["nvim-dap"];
 
-    vim.luaConfigRC.nvim-dap-ui = nvim.dag.entryAnywhere ''
-      require("dapui").setup()
-    '';
-  };
+      vim.luaConfigRC.nvim-dap =
+        nvim.dag.entryAnywhere ''
+        '';
+    })
+    (mkIf (cfg.enable && cfg.ui.enable) {
+      vim.startPlugins = ["nvim-dap-ui"];
+
+      vim.luaConfigRC.nvim-dap-ui = nvim.dag.entryAfter ["nvim-dap"] (''
+          local dapui = require("dapui")
+          require("dapui").setup()
+        ''
+        + optionalString cfg.ui.autoStart ''
+          dap.listeners.after.event_initialized["dapui_config"] = function()
+            dapui.open()
+          end
+          dap.listeners.before.event_terminated["dapui_config"] = function()
+            dapui.close()
+          end
+          dap.listeners.before.event_exited["dapui_config"] = function()
+            dapui.close()
+          end
+        '');
+    })
+  ];
 }

--- a/modules/debugger/nvim-dap/config.nix
+++ b/modules/debugger/nvim-dap/config.nix
@@ -11,9 +11,13 @@ in {
     (mkIf cfg.enable {
       vim.startPlugins = ["nvim-dap"];
 
-      vim.luaConfigRC.nvim-dap =
-        nvim.dag.entryAnywhere ''
-        '';
+      vim.luaConfigRC =
+        {
+          nvim-dap = nvim.dag.entryAnywhere ''
+            local dap = require("dap")
+          '';
+        }
+        // mapAttrs (_: v: (nvim.dag.entryAfter ["nvim-dap"] v)) cfg.sources;
     })
     (mkIf (cfg.enable && cfg.ui.enable) {
       vim.startPlugins = ["nvim-dap-ui"];

--- a/modules/debugger/nvim-dap/config.nix
+++ b/modules/debugger/nvim-dap/config.nix
@@ -13,8 +13,28 @@ in {
 
       vim.luaConfigRC =
         {
+          # TODO customizable keymaps
           nvim-dap = nvim.dag.entryAnywhere ''
             local dap = require("dap")
+            local opts = { noremap = true, silent = true }
+
+            vim.keymap.set("n", "<leader>d.", "<cmd>lua require'dap'.run_last()<cr>", opts)
+            vim.keymap.set("n", "<leader>dR", "<cmd>lua require'dap'.restart()<cr>", opts)
+            vim.keymap.set("n", "<leader>dq", "<cmd>lua require'dap'.terminate()<cr>", opts)
+            vim.keymap.set("n", "<leader>db", "<cmd>lua require'dap'.toggle_breakpoint()<cr>", opts)
+            vim.keymap.set("n", "<leader>dc", "<cmd>lua require'dap'.continue()<cr>", opts)
+            vim.keymap.set("n", "<leader>dl", "<cmd>lua require'dap'.set_breakpoint(nil, nil, vim.fn.input('Log point message: '))<cr>", opts)
+            vim.keymap.set("n", "<leader>dgb", "<cmd>lua require'dap'.continue()<cr>", opts)
+            vim.keymap.set("n", "<leader>dgc", "<cmd>lua require'dap'.run_to_cursor()<cr>", opts)
+            vim.keymap.set("n", "<leader>dgi", "<cmd>lua require'dap'.step_into()<cr>", opts)
+            vim.keymap.set("n", "<leader>dgo", "<cmd>lua require'dap'.step_out()<cr>", opts)
+            vim.keymap.set("n", "<leader>dgI", "<cmd>lua require'dap'.down()<cr>", opts)
+            vim.keymap.set("n", "<leader>dgO", "<cmd>lua require'dap'.up()<cr>", opts)
+            vim.keymap.set("n", "<leader>dgj", "<cmd>lua require'dap'.step_over()<cr>", opts)
+            vim.keymap.set("n", "<leader>dgk", "<cmd>lua require'dap'.step_back()<cr>", opts)
+            vim.keymap.set("n", "<leader>dr", "<cmd>lua require'dap'.repl.toggle()<cr>", opts)
+            vim.keymap.set("n", "<leader>dh", "<cmd>lua require'dap.ui.widgets'.hover()<cr>", opts)
+
           '';
         }
         // mapAttrs (_: v: (nvim.dag.entryAfter ["nvim-dap"] v)) cfg.sources;
@@ -25,6 +45,8 @@ in {
       vim.luaConfigRC.nvim-dap-ui = nvim.dag.entryAfter ["nvim-dap"] (''
           local dapui = require("dapui")
           require("dapui").setup()
+          vim.keymap.set("n", "<leader>du", "<cmd>lua require'dapui'.toggle()<cr>", opts)
+          vim.keymap.set({ "n", "v" }, "<leader>dd", "<cmd>lua require'dapui'.eval()<cr>", opts)
         ''
         + optionalString cfg.ui.autoStart ''
           dap.listeners.after.event_initialized["dapui_config"] = function()

--- a/modules/debugger/nvim-dap/config.nix
+++ b/modules/debugger/nvim-dap/config.nix
@@ -21,6 +21,7 @@ in {
           # TODO customizable keymaps
           nvim-dap = nvim.dag.entryAnywhere ''
             local dap = require("dap")
+            vim.fn.sign_define("DapBreakpoint", { text = "🛑", texthl = "ErrorMsg", linehl = "", numhl = "" })
           '';
         }
         // mapAttrs (_: v: (nvim.dag.entryAfter ["nvim-dap"] v)) cfg.sources;

--- a/modules/debugger/nvim-dap/default.nix
+++ b/modules/debugger/nvim-dap/default.nix
@@ -1,0 +1,6 @@
+_: {
+  imports = [
+    ./config.nix
+    ./nvim-dap.nix
+  ];
+}

--- a/modules/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/debugger/nvim-dap/nvim-dap.nix
@@ -1,0 +1,10 @@
+{lib, ...}:
+with lib; {
+  options.vim.debugger.nvim-dap = {
+    enable = mkEnableOption "Enable debugging via nvim-dap";
+
+    ui = {
+      enable = mkEnableOption "Enable UI extension for nvim-dap";
+    };
+  };
+}

--- a/modules/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/debugger/nvim-dap/nvim-dap.nix
@@ -5,6 +5,11 @@ with lib; {
 
     ui = {
       enable = mkEnableOption "Enable UI extension for nvim-dap";
+      autoStart = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Automatically Opens and Closes DAP-UI upon starting/closing a debugging session";
+      };
     };
   };
 }

--- a/modules/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/debugger/nvim-dap/nvim-dap.nix
@@ -11,5 +11,11 @@ with lib; {
         description = "Automatically Opens and Closes DAP-UI upon starting/closing a debugging session";
       };
     };
+
+    sources = mkOption {
+      default = {};
+      description = "List of debuggers to install";
+      type = with types; attrsOf string;
+    };
   };
 }

--- a/modules/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/debugger/nvim-dap/nvim-dap.nix
@@ -17,5 +17,27 @@ with lib; {
       description = "List of debuggers to install";
       type = with types; attrsOf string;
     };
+
+    mappings = {
+      continue = mkMappingOption "Contiue" "<leader>dc";
+      restart = mkMappingOption "Restart" "<leader>dR";
+      terminate = mkMappingOption "Terminate" "<leader>dq";
+      runLast = mkMappingOption "Re-run Last Debug Session" "<leader>d.";
+
+      toggleRepl = mkMappingOption "Toggle Repl" "<leader>dr";
+      hover = mkMappingOption "Hover" "<leader>dh";
+      toggleBreakpoint = mkMappingOption "Toggle breakpoint" "<leader>db";
+
+      runToCursor = mkMappingOption "Continue to the current cursor" "<leader>dgc";
+      stepInto = mkMappingOption "Step into function" "<leader>dgi";
+      stepOut = mkMappingOption "Step out of function" "<leader>dgo";
+      stepOver = mkMappingOption "Next step" "<leader>dgj";
+      stepBack = mkMappingOption "Step back" "<leader>dgk";
+
+      goUp = mkMappingOption "Go up stacktrace" "<leader>dvo";
+      goDown = mkMappingOption "Go down stacktrace" "<leader>dvi";
+
+      toggleDapUI = mkMappingOption "Toggle DAP-UI" "<leader>du";
+    };
   };
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -25,13 +25,13 @@ inputs: {
       // extraSpecialArgs;
   };
 
-  buildPlug = name:
-    buildVimPluginFrom2Nix rec {
-      pname = name;
-      version = "master";
-      src = assert lib.asserts.assertMsg (name != "nvim-treesitter") "Use buildTreesitterPlug for building nvim-treesitter.";
-        getAttr pname inputs;
-    };
+  buildPlug = {pname, ...} @ args:
+    assert lib.asserts.assertMsg (pname != "nvim-treesitter") "Use buildTreesitterPlug for building nvim-treesitter.";
+      buildVimPluginFrom2Nix (args
+        // {
+          version = "master";
+          src = getAttr pname inputs;
+        });
 
   buildTreesitterPlug = grammars: vimPlugins.nvim-treesitter.withPlugins (_: grammars);
 
@@ -45,7 +45,13 @@ inputs: {
         (
           if (plug == "nvim-treesitter")
           then (buildTreesitterPlug vimOptions.treesitter.grammars)
-          else (buildPlug plug)
+          else if (plug == "flutter-tools-patched")
+          then
+            (buildPlug {
+              pname = "flutter-tools";
+              patches = [../patches/flutter-tools.patch];
+            })
+          else (buildPlug {pname = plug;})
         )
       else plug
     ))

--- a/modules/languages/dart/config.nix
+++ b/modules/languages/dart/config.nix
@@ -55,8 +55,12 @@ in {
             on_attach = default_on_attach;
             flags = lsp_flags,
           },
+          ${optionalString cfg.dap.enable ''
+          debugger = {
+            enabled = true,
+          },
+        ''}
         }
-
       '';
     })
   ]);

--- a/modules/languages/dart/config.nix
+++ b/modules/languages/dart/config.nix
@@ -35,7 +35,10 @@ in {
     })
 
     (mkIf (ftcfg.enable) {
-      vim.startPlugins = ["flutter-tools"];
+      vim.startPlugins =
+        if ftcfg.enableNoResolvePatch
+        then ["flutter-tools-patched"]
+        else ["flutter-tools"];
 
       vim.luaConfigRC.flutter-tools = nvim.dag.entryAnywhere ''
         require('flutter-tools').setup {

--- a/modules/languages/dart/dart.nix
+++ b/modules/languages/dart/dart.nix
@@ -56,6 +56,16 @@ in {
         default = config.vim.languages.enableLSP;
       };
 
+      enableNoResolvePatch = mkOption {
+        description = ''
+          Patch flutter-tools so that it doesn't resolve symlinks when detecting flutter path.
+          This is required if you want to use a flutter package built with nix.
+          If you are using a flutter SDK installed from a different source and encounter the error "`dart` missing from PATH", disable this option.
+        '';
+        type = types.bool;
+        default = true;
+      };
+
       color = {
         enable = mkEnableOption "Whether or mot to highlight color variables at all";
 

--- a/modules/languages/dart/dart.nix
+++ b/modules/languages/dart/dart.nix
@@ -49,6 +49,14 @@ in {
       };
     };
 
+    dap = {
+      enable = mkOption {
+        description = "Enable Dart DAP support via flutter-tools";
+        type = types.bool;
+        default = config.vim.languages.enableDAP;
+      };
+    };
+
     flutter-tools = {
       enable = mkOption {
         description = "Enable flutter-tools for flutter support";

--- a/modules/languages/default.nix
+++ b/modules/languages/default.nix
@@ -27,6 +27,7 @@ in {
 
   options.vim.languages = {
     enableLSP = mkEnable "LSP";
+    enableDAP = mkEnable "Debug Adapter";
     enableTreesitter = mkEnable "treesitter";
     enableFormat = mkEnable "formatting";
     enableExtraDiagnostics = mkEnable "extra diagnostics";

--- a/modules/languages/go.nix
+++ b/modules/languages/go.nix
@@ -21,6 +21,46 @@ with builtins; let
       '';
     };
   };
+  defaultDebugger = "delve";
+  debuggers = {
+    delve = {
+      package = pkgs.delve;
+      dapConfig = ''
+        dap.adapters.delve = {
+          type = "server",
+          port = "''${port}",
+          executable = {
+            command = "${getExe cfg.dap.package}",
+            args = { "dap", "-l", "127.0.0.1:''${port}" },
+          },
+        }
+
+        dap.configurations.go = {
+          {
+            type = "delve",
+            name = "Debug",
+            request = "launch",
+            program = "''${file}",
+          },
+          {
+            type = "delve",
+            name = "Debug test", -- configuration for debugging test files
+            request = "launch",
+            mode = "test",
+            program = "''${file}",
+          },
+          -- works with go.mod packages and sub packages
+          {
+            type = "delve",
+            name = "Debug test (go.mod)",
+            request = "launch",
+            mode = "test",
+            program = "./''${relativeFileDirname}",
+          },
+        }
+      '';
+    };
+  };
 in {
   options.vim.languages.go = {
     enable = mkEnableOption "Go language support";
@@ -46,6 +86,24 @@ in {
         default = servers.${cfg.lsp.server}.package;
       };
     };
+
+    dap = {
+      enable = mkOption {
+        description = "Enable Go Debug Adapter";
+        type = types.bool;
+        default = config.vim.languages.enableDAP;
+      };
+      debugger = mkOption {
+        description = "Go debugger to use";
+        type = with types; enum (attrNames debuggers);
+        default = defaultDebugger;
+      };
+      package = mkOption {
+        description = "Go debugger package.";
+        type = types.package;
+        default = debuggers.${cfg.dap.debugger}.package;
+      };
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -57,6 +115,11 @@ in {
     (mkIf cfg.lsp.enable {
       vim.lsp.lspconfig.enable = true;
       vim.lsp.lspconfig.sources.go-lsp = servers.${cfg.lsp.server}.lspConfig;
+    })
+
+    (mkIf cfg.dap.enable {
+      vim.debugger.nvim-dap.enable = true;
+      vim.debugger.nvim-dap.sources.go-debugger = debuggers.${cfg.dap.debugger}.dapConfig;
     })
   ]);
 }

--- a/modules/languages/python.nix
+++ b/modules/languages/python.nix
@@ -36,6 +36,69 @@ with builtins; let
       '';
     };
   };
+
+  defaultDebugger = "debugpy";
+  debuggers = {
+    debugpy = {
+      # idk if this is the best way to install/run debugpy
+      package = pkgs.python3.withPackages (ps: with ps; [debugpy]);
+      dapConfig = ''
+        dap.adapters.python = function(cb, config)
+          if config.request == 'attach' then
+            ---@diagnostic disable-next-line: undefined-field
+            local port = (config.connect or config).port
+            ---@diagnostic disable-next-line: undefined-field
+            local host = (config.connect or config).host or '127.0.0.1'
+            cb({
+              type = 'server',
+              port = assert(port, '`connect.port` is required for a python `attach` configuration'),
+              host = host,
+              options = {
+                source_filetype = 'python',
+              },
+            })
+          else
+            cb({
+              type = 'executable',
+              command = '${getExe cfg.dap.package}',
+              args = { '-m', 'debugpy.adapter' },
+              options = {
+                source_filetype = 'python',
+              },
+            })
+          end
+        end
+
+        dap.configurations.python = {
+          {
+            -- The first three options are required by nvim-dap
+            type = 'python'; -- the type here established the link to the adapter definition: `dap.adapters.python`
+            request = 'launch';
+            name = "Launch file";
+
+            -- Options below are for debugpy, see https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings for supported options
+
+            program = "''${file}"; -- This configuration will launch the current file if used.
+            pythonPath = function()
+              -- debugpy supports launching an application with a different interpreter then the one used to launch debugpy itself.
+              -- The code below looks for a `venv` or `.venv` folder in the current directly and uses the python within.
+              -- You could adapt this - to for example use the `VIRTUAL_ENV` environment variable.
+              local cwd = vim.fn.getcwd()
+              if vim.fn.executable(cwd .. '/venv/bin/python') == 1 then
+                return cwd .. '/venv/bin/python'
+              elseif vim.fn.executable(cwd .. '/.venv/bin/python') == 1 then
+                return cwd .. '/.venv/bin/python'
+              elseif vim.fn.executable("python") == 1 then
+                return vim.fn.exepath("python")
+              else -- WARNING cfg.dap.package probably has NO libraries other than builtins and debugpy
+                return '${getExe cfg.dap.package}'
+              end
+            end;
+          },
+        }
+      '';
+    };
+  };
 in {
   options.vim.languages.python = {
     enable = mkEnableOption "Python language support";
@@ -80,6 +143,29 @@ in {
         default = formats.${cfg.format.type}.package;
       };
     };
+
+    # TODO this implementation is very bare bones, I don't know enough python to implement everything
+    dap = {
+      enable = mkOption {
+        description = "Enable Python Debug Adapter";
+        type = types.bool;
+        default = config.vim.languages.enableDAP;
+      };
+      debugger = mkOption {
+        description = "Python debugger to use";
+        type = with types; enum (attrNames debuggers);
+        default = defaultDebugger;
+      };
+      package = mkOption {
+        description = ''
+          Python debugger package.
+          This is a python package with debugpy installed, see https://nixos.wiki/wiki/Python#Install_Python_Packages.
+        '';
+        example = literalExpression "with pkgs; python39.withPackages (ps: with ps; [debugpy])";
+        type = types.package;
+        default = debuggers.${cfg.dap.debugger}.package;
+      };
+    };
   };
   config = mkIf cfg.enable (mkMerge [
     (mkIf cfg.treesitter.enable {
@@ -95,6 +181,11 @@ in {
     (mkIf cfg.format.enable {
       vim.lsp.null-ls.enable = true;
       vim.lsp.null-ls.sources.python-format = formats.${cfg.format.type}.nullConfig;
+    })
+
+    (mkIf cfg.dap.enable {
+      vim.debugger.nvim-dap.enable = true;
+      vim.debugger.nvim-dap.sources.python-debugger = debuggers.${cfg.dap.debugger}.dapConfig;
     })
   ]);
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -29,6 +29,7 @@
     ./comments
     ./projects
     ./languages
+    ./debugger
   ];
 
   pkgsModule = {config, ...}: {

--- a/patches/flutter-tools.patch
+++ b/patches/flutter-tools.patch
@@ -1,0 +1,41 @@
+diff --git a/lua/flutter-tools/executable.lua b/lua/flutter-tools/executable.lua
+index 3807a4f..3345760 100644
+--- a/lua/flutter-tools/executable.lua
++++ b/lua/flutter-tools/executable.lua
+@@ -31,12 +31,12 @@ local function _dart_sdk_root(paths)
+   end
+ 
+   if utils.executable("flutter") then
+-    local flutter_path = fn.resolve(fn.exepath("flutter"))
++    local flutter_path = fn.exepath("flutter")
+     local flutter_bin = fn.fnamemodify(flutter_path, ":h")
+     return path.join(flutter_bin, dart_sdk)
+   end
+ 
+-  if utils.executable("dart") then return fn.resolve(fn.exepath("dart")) end
++  if utils.executable("dart") then return fn.exepath("dart") end
+ 
+   return ""
+ end
+@@ -50,10 +50,10 @@ end
+ ---Get paths for flutter and dart based on the binary locations
+ ---@return table<string, string>
+ local function get_default_binaries()
+-  local flutter_bin = fn.resolve(fn.exepath("flutter"))
++  local flutter_bin = fn.exepath("flutter")
+   return {
+     flutter_bin = flutter_bin,
+-    dart_bin = fn.resolve(fn.exepath("dart")),
++    dart_bin = fn.exepath("dart"),
+     flutter_sdk = _flutter_sdk_root(flutter_bin),
+   }
+ end
+@@ -119,7 +119,7 @@ function M.get(callback)
+   end
+ 
+   if config.flutter_path then
+-    local flutter_path = fn.resolve(config.flutter_path)
++    local flutter_path = config.flutter_path
+     _paths = { flutter_bin = flutter_path, flutter_sdk = _flutter_sdk_root(flutter_path) }
+     _paths.dart_sdk = _dart_sdk_root(_paths)
+     _paths.dart_bin = _flutter_sdk_dart_bin(_paths.flutter_sdk)


### PR DESCRIPTION
Add support for debug adaptor protocol (DAP) via nvim-dap.

## Note

- ~~nvim-dap-ui is kinda broken in nvim-0.9, but will be fixed in 9.1: https://github.com/rcarriga/nvim-dap-ui/issues/262~~ fixed in nvim 0.9.1

- [x] nvim-dap
  - [x] custom keybinds
- [x] nvim-dap-ui
  - [x] custom keybinds
- [ ] languages
  - [ ] dart
  - [ ] elixir
  - [x] clang
  - [x] go
  - [x] python
  - [x] rust
  - [ ] ts
  - ~~[ ] html~~
  - ~~[ ] nix~~
  - ~~[ ] sql~~
  - ~~[ ] markdown~~
  - ~~[ ] tidal~~
  - ~~[ ] zig~~

I'll add basic configurations for supported languages, but I can only test go, python, rust and c/++.

## References

[nvim-dap's Debug Adapter Installation wiki](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation)