### PR TITLE
Feature/wakatime

### DIFF
--- a/extra.nix
+++ b/extra.nix
@@ -151,6 +151,7 @@ inputs: let
 
       vim.utility = {
         colorizer.enable = true;
+        vim-wakatime.enable = true;
         icon-picker.enable = true;
         diffview-nvim.enable = true;
         motion = {

--- a/flake.lock
+++ b/flake.lock
@@ -1359,6 +1359,7 @@
         "vim-repeat": "vim-repeat",
         "vim-startify": "vim-startify",
         "vim-vsnip": "vim-vsnip",
+        "vim-wakatime": "vim-wakatime",
         "which-key": "which-key",
         "zig": "zig"
       }
@@ -1729,6 +1730,22 @@
       "original": {
         "owner": "hrsh7th",
         "repo": "vim-vsnip",
+        "type": "github"
+      }
+    },
+    "vim-wakatime": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683640992,
+        "narHash": "sha256-DIj+ps5XfpFHwBJ42EBw5ayHfdzCc+bDvpyYm/p+9Ec=",
+        "owner": "wakatime",
+        "repo": "vim-wakatime",
+        "rev": "02be9238319937e04afea73fd0fc7da5413ee041",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wakatime",
+        "repo": "vim-wakatime",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -373,6 +373,11 @@
     };
 
     # Utilities
+    vim-wakatime = {
+      url = "github:wakatime/vim-wakatime";
+      flake = false;
+    };
+
     colorizer = {
       url = "github:uga-rosa/ccc.nvim";
       flake = false;

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -81,6 +81,7 @@ with lib; let
     "project-nvim"
     "elixir-ls"
     "elixir-tools"
+    "vim-wakatime"
   ];
   # You can either use the name of the plugin or a package.
   pluginsType = with types;

--- a/modules/utility/default.nix
+++ b/modules/utility/default.nix
@@ -8,5 +8,6 @@ _: {
     ./icon-picker
     ./telescope
     ./diffview
+    ./wakatime
   ];
 }

--- a/modules/utility/wakatime/config.nix
+++ b/modules/utility/wakatime/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 with lib;
@@ -9,7 +10,7 @@ with builtins; let
 in {
   config = mkIf (cfg.enable) {
     vim.startPlugins = [
-      "vim-wakatime"
+      pkgs.vimPlugins.vim-wakatime
     ];
   };
 }

--- a/modules/utility/wakatime/config.nix
+++ b/modules/utility/wakatime/config.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.utility.vim-wakatime;
+in {
+  config = mkIf (cfg.enable) {
+    vim.startPlugins = [
+      "vim-wakatime"
+    ];
+  };
+}

--- a/modules/utility/wakatime/default.nix
+++ b/modules/utility/wakatime/default.nix
@@ -1,0 +1,6 @@
+_: {
+  imports = [
+    ./config.nix
+    ./vim-wakatime.nix
+  ];
+}

--- a/modules/utility/wakatime/vim-wakatime.nix
+++ b/modules/utility/wakatime/vim-wakatime.nix
@@ -1,0 +1,8 @@
+{lib, ...}:
+with lib;
+with builtins; {
+  options.vim.utility.vim-wakatime = {
+    enable = mkEnableOption "Enable vim-wakatime";
+  };
+}
+


### PR DESCRIPTION
Adds [vim-wakatime](https://github.com/wakatime/vim-wakatime) plugin.

Pulls the plugin from **nixpkgs** instead of using flake inputs due to the nix sandbox preventing the plugin from fetching its dependencies.