### PR TITLE
feat: make it possible to use strings for the RC

### DIFF
--- a/docs/custom-plugins.adoc
+++ b/docs/custom-plugins.adoc
@@ -1,0 +1,34 @@
+[[ch-custom-plugins]]
+== Custom Plugins
+
+You can use custom plugins, before they are implemented in the flake.
+To add a plugin, you need to add it to your config's `config.vim.startPlugins` array.
+This is an example of adding the FrenzyExists/aquarium-vim plugin:
+
+[source,nix]
+----
+{
+  config.vim.startPlugins = [
+    (pkgs.fetchFromGitHub {
+      owner = "FrenzyExists";
+      repo = "aquarium-vim";
+      rev = "d09b1feda1148797aa5ff0dbca8d8e3256d028d5";
+      sha256 = "CtyEhCcGxxok6xFQ09feWpdEBIYHH+GIFVOaNZx10Bs=";
+    })
+  ];
+}
+----
+
+However, just making the plugin available might not be enough. In that case, you can write custom vimscript or lua config, using `config.vim.configRC` or `config.vim.luaConfigRC` respectively.
+These options are attribute sets, and you need to give the configuration you're adding some name, like this:
+
+[source,nix]
+----
+{
+  config.vim.configRC.aquarium = "colorscheme aquiarum";
+}
+----
+
+Note: If your configuration needs to be put in a specific place in the config, you can use functions from `inputs.neovim-flake.lib.nvim.dag` to order it. Refer to https://github.com/nix-community/home-manager/blob/master/modules/lib/dag.nix.
+
+Also, if you successfully made your plugin work, please make a PR to add it to the flake, or open an issue with your findings so that we can make it available for everyone easily.

--- a/docs/manual.xml
+++ b/docs/manual.xml
@@ -19,6 +19,7 @@
  <xi:include href="try-it-out.xml"/>
  <xi:include href="default-configs.xml"/>
  <xi:include href="custom-configs.xml"/>
+ <xi:include href="custom-plugins.xml"/>
  <xi:include href="home-manager.xml"/>
  <xi:include href="languages.xml"/>
  <appendix xml:id="ch-options">

--- a/docs/release-notes/rl-0.4.adoc
+++ b/docs/release-notes/rl-0.4.adoc
@@ -16,6 +16,8 @@ https://github.com/n3oney[n3oney]:
 
 * Moved default keybinds into keybinds section of each module
 
+* Simplified luaConfigRC and configRC setting - they can now just take strings
+
 https://github.com/horriblename[horriblename]:
 
 * Added `clangd` as alternative lsp for C/++.

--- a/docs/release-notes/rl-0.4.adoc
+++ b/docs/release-notes/rl-0.4.adoc
@@ -18,6 +18,8 @@ https://github.com/n3oney[n3oney]:
 
 * Simplified luaConfigRC and configRC setting - they can now just take strings
 
+* Refactored the resolveDag function - you can just provide a string now, which will default to dag.entryAnywhere
+
 https://github.com/horriblename[horriblename]:
 
 * Added `clangd` as alternative lsp for C/++.

--- a/modules/core/default.nix
+++ b/modules/core/default.nix
@@ -132,13 +132,13 @@ in {
 
     configRC = mkOption {
       description = "vimrc contents";
-      type = nvim.types.dagOf types.lines;
+      type = types.oneOf [(nvim.types.dagOf types.lines) types.str];
       default = {};
     };
 
     luaConfigRC = mkOption {
       description = "vim lua config";
-      type = nvim.types.dagOf types.lines;
+      type = types.oneOf [(nvim.types.dagOf types.lines) types.str];
       default = {};
     };
 
@@ -282,7 +282,12 @@ in {
       dag,
       mapResult,
     }: let
-      sortedDag = nvim.dag.topoSort dag;
+      finalDag = lib.mapAttrs (name: value:
+        if builtins.isString value
+        then nvim.dag.entryAnywhere value
+        else value)
+      dag;
+      sortedDag = nvim.dag.topoSort finalDag;
       result =
         if sortedDag ? result
         then mapResult sortedDag.result

--- a/modules/core/default.nix
+++ b/modules/core/default.nix
@@ -282,6 +282,7 @@ in {
       dag,
       mapResult,
     }: let
+      # When the value is a string, default it to dag.entryAnywhere
       finalDag = lib.mapAttrs (name: value:
         if builtins.isString value
         then nvim.dag.entryAnywhere value


### PR DESCRIPTION
before, when you wanted to provide some kind of custom config, you had to do this:
```nix
{
  configRC.aquarium-vim = inputs.neovim-flake.lib.nvim.dag.entryAnywhere "colorscheme aquarium";
}
```

with this PR, this is enough:

```nix
{
  configRC.aquarium-vim = "colorscheme aquarium";
}
```

it will give the exact same result, as passing just a string to the RC will make it use nvim.dag.entryAnywhere under the hood.