### PR TITLE
feat: give null-ls priority over other formatters

### DIFF
--- a/docs/release-notes/rl-0.4.adoc
+++ b/docs/release-notes/rl-0.4.adoc
@@ -20,7 +20,11 @@ https://github.com/n3oney[n3oney]:
 
 * Refactored the resolveDag function - you can just provide a string now, which will default to dag.entryAnywhere
 
-* Fixed formatting issues and gave null-ls priority over other formatters
+* Fixed formatting sometimes removing parts of files
+
+* Made formatting synchronous
+
+* Gave null-ls priority over other formatters
 
 https://github.com/horriblename[horriblename]:
 

--- a/docs/release-notes/rl-0.4.adoc
+++ b/docs/release-notes/rl-0.4.adoc
@@ -20,6 +20,8 @@ https://github.com/n3oney[n3oney]:
 
 * Refactored the resolveDag function - you can just provide a string now, which will default to dag.entryAnywhere
 
+* Fixed formatting issues and gave null-ls priority over other formatters
+
 https://github.com/horriblename[horriblename]:
 
 * Added `clangd` as alternative lsp for C/++.

--- a/modules/lsp/config.nix
+++ b/modules/lsp/config.nix
@@ -39,15 +39,43 @@ in {
       local augroup = vim.api.nvim_create_augroup("LspFormatting", {})
 
       format_callback = function(client, bufnr)
-        if vim.g.formatsave and client.supports_method("textDocument/formatting") then
+        if vim.g.formatsave then
           vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
           vim.api.nvim_create_autocmd("BufWritePre", {
             group = augroup,
             buffer = bufnr,
             callback = function()
-              vim.lsp.buf.format({
-                bufnr = bufnr
+              ${
+        if config.vim.lsp.null-ls.enable
+        then ''
+          local function is_null_ls_formatting_enabled(bufnr)
+              local file_type = vim.api.nvim_buf_get_option(bufnr, "filetype")
+              local generators = require("null-ls.generators").get_available(
+                  file_type,
+                  require("null-ls.methods").internal.FORMATTING
+              )
+              return #generators > 0
+          end
+
+          if is_null_ls_formatting_enabled(bufnr) then
+             vim.lsp.buf.format({
+                bufnr = bufnr,
+                filter = function(client)
+                  return client.name == "null-ls"
+                end
               })
+          else
+              vim.lsp.buf.format({
+                bufnr = bufnr,
+              })
+          end
+        ''
+        else "
+              vim.lsp.buf.format({
+                bufnr = bufnr,
+              })
+        "
+      }
             end,
           })
         end


### PR DESCRIPTION
this PR fixes an issue I've had with formatting - when coding in TS, prettier would format the code fine, but so would tsserver, resulting in prettier being useless.
Before, I've tried to just filter every formatter that isn't null-ls to fix that issue, but that is not a good workaround as some languages don't have null-ls for formatting.

This pr introduces a better solution - it filters all formatters except null-ls, only when null-ls *can* format the file, which is pretty much the behaviour you'd expect.

*@horriblename could you test if this works fine for you? Thank you.*