### PR TITLE
fix(flutter-tools): bug where dart lsp is not found

### DIFF
--- a/docs/release-notes/rl-0.4.adoc
+++ b/docs/release-notes/rl-0.4.adoc
@@ -1,6 +1,5 @@
 [[sec-release-0.4]]
 == Release 0.4
-
 Following the release of v0.3, I have decided to release v0.4 with a massive new change: customizable keybinds. As of the 0.4 release, keybinds will no longer be hardcoded and instead provided by each module's own keybinds section. The old keybind system (`vim.keybinds = {}`) is now considered deprecated and the new lib functions are recommended to be used for adding keybinds for new plugins, or adding keybinds to existing plugins.
 
 Alongside customizable keybinds, there are a few quality of life updates, such as `lazygit` integration and the new experimental Lua loader of Neovim 0.9 thanks to our awesome contributors who made this update possible during my absence.
@@ -33,6 +32,8 @@ https://github.com/horriblename[horriblename]:
 * Added `toggleterm` integration for `lazygit`.
 
 * Added new option `enableluaLoader` to enable neovim's experimental module loader for faster startup time.
+
+* Fixed bug where flutter-tools can't find `dart` LSP
 
 https://github.com/notashelf[notashelf]:
 

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -73,6 +73,7 @@ with lib; let
     "diffview-nvim"
     "todo-comments"
     "flutter-tools"
+    "flutter-tools-patched"
     "hop-nvim"
     "leap-nvim"
     "modes-nvim"

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -25,13 +25,13 @@ inputs: {
       // extraSpecialArgs;
   };
 
-  buildPlug = name:
-    buildVimPluginFrom2Nix rec {
-      pname = name;
-      version = "master";
-      src = assert lib.asserts.assertMsg (name != "nvim-treesitter") "Use buildTreesitterPlug for building nvim-treesitter.";
-        getAttr pname inputs;
-    };
+  buildPlug = {pname, ...} @ args:
+    assert lib.asserts.assertMsg (pname != "nvim-treesitter") "Use buildTreesitterPlug for building nvim-treesitter.";
+      buildVimPluginFrom2Nix (args
+        // {
+          version = "master";
+          src = getAttr pname inputs;
+        });
 
   buildTreesitterPlug = grammars: vimPlugins.nvim-treesitter.withPlugins (_: grammars);
 
@@ -45,7 +45,13 @@ inputs: {
         (
           if (plug == "nvim-treesitter")
           then (buildTreesitterPlug vimOptions.treesitter.grammars)
-          else (buildPlug plug)
+          else if (plug == "flutter-tools-patched")
+          then
+            (buildPlug {
+              pname = "flutter-tools";
+              patches = [../patches/flutter-tools.patch];
+            })
+          else (buildPlug {pname = plug;})
         )
       else plug
     ))

--- a/modules/languages/dart/config.nix
+++ b/modules/languages/dart/config.nix
@@ -35,7 +35,10 @@ in {
     })
 
     (mkIf (ftcfg.enable) {
-      vim.startPlugins = ["flutter-tools"];
+      vim.startPlugins =
+        if ftcfg.enableNoResolvePatch
+        then ["flutter-tools-patched"]
+        else ["flutter-tools"];
 
       vim.luaConfigRC.flutter-tools = nvim.dag.entryAnywhere ''
         require('flutter-tools').setup {

--- a/modules/languages/dart/dart.nix
+++ b/modules/languages/dart/dart.nix
@@ -56,6 +56,16 @@ in {
         default = config.vim.languages.enableLSP;
       };
 
+      enableNoResolvePatch = mkOption {
+        description = ''
+          Patch flutter-tools so that it doesn't resolve symlinks when detecting flutter path.
+          This is required if you want to use a flutter package built with nix.
+          If you are using a flutter SDK installed from a different source and encounter the error "`dart` missing from PATH", disable this option.
+        '';
+        type = types.bool;
+        default = true;
+      };
+
       color = {
         enable = mkEnableOption "Whether or mot to highlight color variables at all";
 

--- a/patches/flutter-tools.patch
+++ b/patches/flutter-tools.patch
@@ -1,0 +1,41 @@
+diff --git a/lua/flutter-tools/executable.lua b/lua/flutter-tools/executable.lua
+index 3807a4f..3345760 100644
+--- a/lua/flutter-tools/executable.lua
++++ b/lua/flutter-tools/executable.lua
+@@ -31,12 +31,12 @@ local function _dart_sdk_root(paths)
+   end
+ 
+   if utils.executable("flutter") then
+-    local flutter_path = fn.resolve(fn.exepath("flutter"))
++    local flutter_path = fn.exepath("flutter")
+     local flutter_bin = fn.fnamemodify(flutter_path, ":h")
+     return path.join(flutter_bin, dart_sdk)
+   end
+ 
+-  if utils.executable("dart") then return fn.resolve(fn.exepath("dart")) end
++  if utils.executable("dart") then return fn.exepath("dart") end
+ 
+   return ""
+ end
+@@ -50,10 +50,10 @@ end
+ ---Get paths for flutter and dart based on the binary locations
+ ---@return table<string, string>
+ local function get_default_binaries()
+-  local flutter_bin = fn.resolve(fn.exepath("flutter"))
++  local flutter_bin = fn.exepath("flutter")
+   return {
+     flutter_bin = flutter_bin,
+-    dart_bin = fn.resolve(fn.exepath("dart")),
++    dart_bin = fn.exepath("dart"),
+     flutter_sdk = _flutter_sdk_root(flutter_bin),
+   }
+ end
+@@ -119,7 +119,7 @@ function M.get(callback)
+   end
+ 
+   if config.flutter_path then
+-    local flutter_path = fn.resolve(config.flutter_path)
++    local flutter_path = config.flutter_path
+     _paths = { flutter_bin = flutter_path, flutter_sdk = _flutter_sdk_root(flutter_path) }
+     _paths.dart_sdk = _dart_sdk_root(_paths)
+     _paths.dart_bin = _flutter_sdk_dart_bin(_paths.flutter_sdk)


### PR DESCRIPTION
Fixes a bug where flutter-tools can't find dart binary when using a wrapped flutter package.

Patch taken from <https://github.com/FlafyDev/nixos-config>
