### PR TITLE
feature/bordered completion windows

### DIFF
--- a/modules/completion/nvim-cmp/config.nix
+++ b/modules/completion/nvim-cmp/config.nix
@@ -182,6 +182,8 @@ in {
       '')
     ];
 
+    # TODO: alternative snippet engines to vsnip
+    # https://github.com/hrsh7th/nvim-cmp/blob/main/doc/cmp.txt#L82
     vim.luaConfigRC.completion = mkIf (cfg.type == "nvim-cmp") (dagPlacement ''
       local nvim_cmp_menu_map = function(entry, vim_item)
         -- name for each source
@@ -195,19 +197,30 @@ in {
       ${optionalString lspkindEnabled ''
         lspkind_opts.before = ${cfg.formatting.format}
       ''}
+
       local cmp = require'cmp'
       cmp.setup({
+        window = {
+          -- TODO: at some point, those need to be optional
+          -- but first nvim cmp module needs to be detached from "cfg.autocomplete"
+          completion = cmp.config.window.bordered(),
+          documentation = cmp.config.window.bordered(),
+        },
+
         snippet = {
           expand = function(args)
             vim.fn["vsnip#anonymous"](args.body)
           end,
         },
+
         sources = {
           ${builtSources}
         },
+
         completion = {
           completeopt = 'menu,menuone,noinsert',
         },
+
         formatting = {
           format =
       ${


### PR DESCRIPTION
Draws a border around nvim-cmp's completion window, should follow the selected theme (only tested with Catppuccin)

Will be optional in the future, current module structure does not allow for a specific option.