### PR TITLE
fix: bufferline overlapping nvimtree with toggleterm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -919,16 +919,15 @@
     "nvim-bufferline-lua": {
       "flake": false,
       "locked": {
-        "lastModified": 1666171880,
-        "narHash": "sha256-hueIGT7KOhca0kP0M1nUYzBrzMz+DpuZSOt5iyuEa40=",
+        "lastModified": 1689661992,
+        "narHash": "sha256-0BJXUDGeUhPALEnPgO4ix+GgI/3P/Foiqi0tf2mgUXg=",
         "owner": "akinsho",
         "repo": "nvim-bufferline.lua",
-        "rev": "e70be6232f632d16d2412b1faf85554285036278",
+        "rev": "d24378edc14a675c820a303b4512af3bbc5761e9",
         "type": "github"
       },
       "original": {
         "owner": "akinsho",
-        "ref": "v3.0.1",
         "repo": "nvim-bufferline.lua",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -181,7 +181,7 @@
 
     # Tablines
     nvim-bufferline-lua = {
-      url = "github:akinsho/nvim-bufferline.lua?ref=v3.0.1";
+      url = "github:akinsho/nvim-bufferline.lua";
       flake = false;
     };
 


### PR DESCRIPTION
Opening Toggleterm pushes the Bufferline on top of Nvimtree column despite the offset being set

https://github.com/NotAShelf/neovim-flake/assets/76622149/f35472b1-418a-461b-bab9-db199d1060ae

The following pull request fixes the issue and has been merged into main:
https://github.com/akinsho/bufferline.nvim/pull/657

