### PR TITLE
feat: make visible borders optional

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -185,6 +185,7 @@ inputs: let
       };
 
       vim.ui = {
+        borders.enable = true;
         noice.enable = true;
         colorizer.enable = true;
         modes-nvim.enable = false; # the theme looks terrible with catppuccin

--- a/modules/completion/nvim-cmp/config.nix
+++ b/modules/completion/nvim-cmp/config.nix
@@ -192,12 +192,13 @@ in {
 
       local cmp = require'cmp'
       cmp.setup({
+        ${optionalString (config.vim.ui.borders.enable) ''
+        -- explicitly enabled by setting ui.borders.enable = true
         window = {
-          -- TODO: at some point, those need to be optional
-          -- but first nvim cmp module needs to be detached from "cfg.autocomplete"
           completion = cmp.config.window.bordered(),
           documentation = cmp.config.window.bordered(),
         },
+      ''}
 
         snippet = {
           expand = function(args)

--- a/modules/lsp/lspconfig/config.nix
+++ b/modules/lsp/lspconfig/config.nix
@@ -16,6 +16,11 @@ in {
 
       vim.luaConfigRC.lspconfig = nvim.dag.entryAfter ["lsp-setup"] ''
         local lspconfig = require('lspconfig')
+
+        ${
+          # TODO: make border style configurable
+          optionalString (config.vim.ui.borders.enable) "require('lspconfig.ui.windows').default_options.border = 'single'"
+        }
       '';
     }
     {

--- a/modules/lsp/lspsaga/config.nix
+++ b/modules/lsp/lspsaga/config.nix
@@ -39,7 +39,9 @@ in {
     vim.luaConfigRC.lspsage = nvim.dag.entryAnywhere ''
       -- Enable lspsaga
       local saga = require 'lspsaga'
-      saga.init_lsp_saga()
+      saga.init_lsp_saga({
+         border_style = 'single',
+      })
     '';
   };
 }

--- a/modules/ui/borders/borders.nix
+++ b/modules/ui/borders/borders.nix
@@ -1,0 +1,9 @@
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption;
+in {
+  options.vim.ui.borders = {
+    enable = mkEnableOption "visible borders for most windows";
+
+    # TODO: make per-plugin borders configurable
+  };
+}

--- a/modules/ui/borders/borders.nix
+++ b/modules/ui/borders/borders.nix
@@ -1,8 +1,12 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption mkOption;
+  inherit (lib) mkEnableOption mkOption types;
 in {
   options.vim.ui.borders = {
-    enable = mkEnableOption "visible borders for most windows";
+    enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = "visible borders for most windows";
+    };
 
     # TODO: make per-plugin borders configurable
   };

--- a/modules/ui/borders/default.nix
+++ b/modules/ui/borders/default.nix
@@ -1,0 +1,5 @@
+_: {
+  imports = [
+    ./borders.nix
+  ];
+}

--- a/modules/ui/default.nix
+++ b/modules/ui/default.nix
@@ -6,5 +6,6 @@ _: {
     ./smartcolumn
     ./colorizer
     ./illuminate
+    ./borders
   ];
 }

--- a/modules/ui/noice/config.nix
+++ b/modules/ui/noice/config.nix
@@ -32,7 +32,7 @@ in {
           command_palette = true, -- position the cmdline and popupmenu together
           long_message_to_split = true, -- long messages will be sent to a split
           inc_rename = false, -- enables an input dialog for inc-rename.nvim
-          lsp_doc_border = false, -- add a border to hover docs and signature help
+          lsp_doc_border = ${builtins.toString (config.vim.ui.borders.enable)}, -- add a border to hover docs and signature help
         },
 
         format = {


### PR DESCRIPTION
We've previously made some borders visible through solid outlines. This PR adds missing window borders, and makes it a toggle behind the `vim.ui.borders.enable` option.

Per plugin borders may be possible in the future.