### PR TITLE
feature/configurable leader key

### DIFF
--- a/modules/basic/config.nix
+++ b/modules/basic/config.nix
@@ -142,6 +142,9 @@ in {
         set spell
         set spelllang=${toString cfg.spellChecking.language}
       ''}
+      ${optionalString (cfg.leaderKey != null) ''
+        let mapleader = "${toString cfg.leaderKey}"
+      ''}
     '';
   };
 }

--- a/modules/basic/module.nix
+++ b/modules/basic/module.nix
@@ -31,6 +31,12 @@ with builtins; {
       };
     };
 
+    leaderKey = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "The leader key to be used internally";
+    };
+
     colourTerm = mkOption {
       type = types.bool;
       default = true;


### PR DESCRIPTION
Allows <Leader> to be customizable. Null means use default (Spacebar)