### PR TITLE
fix/lua syntax mismatch for global formatting and nix language

### DIFF
--- a/modules/languages/nix.nix
+++ b/modules/languages/nix.nix
@@ -56,9 +56,9 @@ with builtins; let
                 command = {"${cfg.format.package}/bin/nixpkgs-fmt"},
               },
             ''}
-        ''}
             },
-          };
+          },
+        ''}
         }
       '';
     };


### PR DESCRIPTION
the nix expression for formatter configuration were missing two curly closing brackets