### PR TITLE
fix/cursorline configuration

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -86,7 +86,7 @@ inputs: let
           eolChar = null;
           showCurrContext = true;
         };
-        cursorWordline = {
+        cursorline = {
           enable = true;
           lineTimeout = 0;
         };

--- a/modules/visuals/config.nix
+++ b/modules/visuals/config.nix
@@ -31,10 +31,15 @@ in {
       '';
     })
 
-    (mkIf cfg.cursorWordline.enable {
+    (mkIf cfg.cursorline.enable {
       vim.startPlugins = ["nvim-cursorline"];
       vim.luaConfigRC.cursorline = nvim.dag.entryAnywhere ''
-        vim.g.cursorline_timeout = ${toString cfg.cursorWordline.lineTimeout}
+        require('nvim-cursorline').setup {
+          cursorline = {
+            timeout = ${toString cfg.cursorline.lineTimeout},
+            number = ${boolToString (!cfg.cursorline.lineNumbersOnly)},
+          }
+        }
       '';
     })
 

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -42,13 +42,19 @@ in {
       };
     };
 
-    cursorWordline = {
-      enable = mkEnableOption "word and delayed line highlight [nvim-cursorline].";
+    cursorline = {
+      enable = mkEnableOption "Enable line hightlighting on the cursor [nvim-cursorline]";
 
       lineTimeout = mkOption {
         type = types.int;
         description = "Time in milliseconds for cursorline to appear";
-        default = 500;
+        default = 0;
+      };
+
+      lineNumbersOnly = mkOption {
+        type = types.bool;
+        description = "Hightlight only in the presence of line numbers";
+        default = true;
       };
     };
 

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -43,7 +43,7 @@ in {
     };
 
     cursorline = {
-      enable = mkEnableOption "Enable line hightlighting on the cursor [nvim-cursorline]";
+      enable = mkEnableOption "line hightlighting on the cursor [nvim-cursorline]";
 
       lineTimeout = mkOption {
         type = types.int;


### PR DESCRIPTION
Fixes `nvim-cursorline` configuration and adds the option `lineNumbersOnly` to disable line highlighting in the absence of line numbers (useful as it looks strange with `dashboard-nvim`).