### PR TITLE
feature/make lsp server installation optional

### DIFF
--- a/lib/types/default.nix
+++ b/lib/types/default.nix
@@ -5,5 +5,5 @@
 in {
   inherit (typesDag) dagOf;
   inherit (typesPlugin) pluginsOpt extraPluginType;
-  inherit (typesLanguage) diagnostics mkGrammarOption;
+  inherit (typesLanguage) diagnostics mkGrammarOption listArgs;
 }

--- a/lib/types/languages.nix
+++ b/lib/types/languages.nix
@@ -1,6 +1,6 @@
 {lib}:
 with lib; let
-  diagnosticSubmodule = {...}: {
+  diagnosticSubmodule = _: {
     options = {
       type = mkOption {
         description = "Type of diagnostic to enable";
@@ -28,4 +28,10 @@ in {
     mkPackageOption pkgs ["${grammar} treesitter"] {
       default = ["vimPlugins" "nvim-treesitter" "builtGrammars" grammar];
     };
+
+  # helper function to return the desired value based on entry type in lsp server cmd
+  pkgOrStr = v:
+    if builtins.isString v
+    then v
+    else lib.getExe v;
 }

--- a/lib/types/languages.nix
+++ b/lib/types/languages.nix
@@ -34,4 +34,9 @@ in {
     if builtins.isString v
     then v
     else lib.getExe v;
+
+  # convert a list of user's LSP args into a list of strings concatenated with commas
+  # for example:
+  #   ["--foo" "--bar"] -> "--foo", "--bar"
+  listArgs = args: builtins.concatStringsSep ", " (map (s: "\"${s}\"") args);
 }


### PR DESCRIPTION
Allow for strings alongside packages for lsp server command to optionally assume the server is already in PATH and avoid download, potentially conflicting with the system version.