### PR TITLE
disable useSystemClipboard by default

### DIFF
--- a/docs/release-notes/rl-0.5.adoc
+++ b/docs/release-notes/rl-0.5.adoc
@@ -53,3 +53,11 @@ https://github.com/notashelf[notashelf]:
 * Added a configuration option for choosing the leader key
 
 * The package used for neovim is now customizable by the user, using <<opt-vim.package>>. For best results, always use an unwrapped package.
+
+https://github.com/jacekpoz[jacekpoz]:
+
+* Fixed scrollOffset not being used
+
+* Updated clangd to 16
+
+* Disabled `useSystemClipboard` by default

--- a/modules/basic/module.nix
+++ b/modules/basic/module.nix
@@ -90,7 +90,7 @@ with builtins; {
 
     useSystemClipboard = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = "Make use of the clipboard for default yank and paste operations. Don't use * and +";
     };
 


### PR DESCRIPTION
doing `"+p` instead of `p` isn't really much of a headache and I don't wanna accidentally paste images into nvim