### PR TITLE
fix: stop using deprecated buildVimPluginFrom2Nix

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -7,7 +7,7 @@ inputs: {
 }: let
   inherit (pkgs) neovim-unwrapped wrapNeovim vimPlugins;
   inherit (builtins) map filter isString toString getAttr;
-  inherit (pkgs.vimUtils) buildVimPluginFrom2Nix;
+  inherit (pkgs.vimUtils) buildVimPlugin;
 
   extendedLib = import ../lib/stdlib-extended.nix lib;
 
@@ -23,7 +23,7 @@ inputs: {
 
   buildPlug = {pname, ...} @ args:
     assert lib.asserts.assertMsg (pname != "nvim-treesitter") "Use buildTreesitterPlug for building nvim-treesitter.";
-      buildVimPluginFrom2Nix (args
+      buildVimPlugin (args
         // {
           version = "master";
           src = getAttr pname inputs;


### PR DESCRIPTION
I tested it by doing 
```
neovim-flake = {
    url = "github:jacekpoz/neovim-flake/plugin-thingy-deprecation";
    inputs.nixpkgs.follows = "nixpkgs";
};
```

and rebuilding, it built and the plugins work