### PR TITLE
modules/visuals: update indent-blankline to v3

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -90,7 +90,7 @@ inputs: let
           fillChar = null;
           eolChar = null;
           scope = {
-            showCurrContext = true;
+            enabled = true;
           };
         };
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -89,7 +89,9 @@ inputs: let
           enable = true;
           fillChar = null;
           eolChar = null;
-          showCurrContext = true;
+          scope = {
+            showCurrContext = true;
+          };
         };
 
         cursorline = {

--- a/docs/release-notes/rl-0.5.adoc
+++ b/docs/release-notes/rl-0.5.adoc
@@ -78,6 +78,8 @@ https://github.com/notashelf[notashelf]:
 To quote home-manager commit: "Output is mostly unchanged aside from some minor typographical and
 formatting changes, along with better source links."
 
+* Updated indent-blankine.nvim to v3 - this comes with a few option changes, which will be migrated with `renamedOptionModule`
+
 
 https://github.com/jacekpoz[jacekpoz]:
 

--- a/flake.lock
+++ b/flake.lock
@@ -584,11 +584,11 @@
     "indent-blankline": {
       "flake": false,
       "locked": {
-        "lastModified": 1688727830,
-        "narHash": "sha256-efMRkxjbr6o7kSKAEn0Kaw8lsDubRmc1N0Kd1BZ3A7k=",
+        "lastModified": 1697081010,
+        "narHash": "sha256-e8gn4pJYALaQ6sGA66SFf8p6VLJBPxT/BimQhOd5eBs=",
         "owner": "lukas-reineke",
         "repo": "indent-blankline.nvim",
-        "rev": "4541d690816cb99a7fc248f1486aa87f3abce91c",
+        "rev": "0fe34b4c1b926e106d105d3ae88ef6cbf6743572",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     "catppuccin": {
       "flake": false,
       "locked": {
-        "lastModified": 1690630440,
-        "narHash": "sha256-MSZcIrV3vvgb5mlMpO5uRlAYoENm2pZyuZbV5Q9Vg58=",
+        "lastModified": 1700667946,
+        "narHash": "sha256-TBOaD7A8/c/sg78C1hUpPDuIrrQkSUQR1KgHiDb6jxs=",
         "owner": "catppuccin",
         "repo": "nvim",
-        "rev": "057c34f849cf21059487d849e2f3b3efcd4ee0eb",
+        "rev": "a2107df4379d66e72a36a89792603151cebec1bf",
         "type": "github"
       },
       "original": {

--- a/modules/visuals/config.nix
+++ b/modules/visuals/config.nix
@@ -12,7 +12,7 @@ in {
       vim.startPlugins = ["indent-blankline"];
       vim.luaConfigRC.indent-blankline = nvim.dag.entryAnywhere ''
         -- highlight error: https://github.com/lukas-reineke/indent-blankline.nvim/issues/59
-        vim.wo.colorcolumn = "99999"
+        -- vim.wo.colorcolumn = "99999"
         vim.opt.list = true
 
         ${optionalString (cfg.indentBlankline.eolChar != null) ''
@@ -22,12 +22,20 @@ in {
           vim.opt.listchars:append({ space = "${cfg.indentBlankline.fillChar}" })
         ''}
 
-        require("indent_blankline").setup {
+        require("ibl").setup {
           enabled = true,
-          char = "${cfg.indentBlankline.listChar}",
-          show_current_context = ${boolToString cfg.indentBlankline.showCurrContext},
-          show_end_of_line = ${boolToString cfg.indentBlankline.showEndOfLine},
-          use_treesitter = ${boolToString cfg.indentBlankline.useTreesitter},
+          debounce = ${toString cfg.indentBlankline.debounce},
+          indent = { char = "${cfg.indentBlankline.indent.char}" },
+
+          viewport_buffer = {
+            min = ${toString cfg.indentBlankline.viewportBuffer.min},
+            max = ${toString cfg.indentBlankline.viewportBuffer.max},
+          },
+
+          scope = {
+            enabled = ${boolToString cfg.indentBlankline.scope.showCurrContext},
+            show_end = ${boolToString cfg.indentBlankline.scope.showEndOfLine}
+          },
         }
       '';
     })

--- a/modules/visuals/config.nix
+++ b/modules/visuals/config.nix
@@ -33,7 +33,7 @@ in {
           },
 
           scope = {
-            enabled = ${boolToString cfg.indentBlankline.scope.showCurrContext},
+            enabled = ${boolToString cfg.indentBlankline.scope.enabled},
             show_end = ${boolToString cfg.indentBlankline.scope.showEndOfLine}
           },
         }

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -8,7 +8,7 @@
   cfg = config.vim.visuals;
 in {
   imports = [
-    (mkRenamedOptionModule ["vim" "visuals" "indentBlankline" "showCurrContext"] ["vim" "visuals" "indentBlankline" "scope" "showCurrContext"])
+    (mkRenamedOptionModule ["vim" "visuals" "indentBlankline" "showCurrContext"] ["vim" "visuals" "indentBlankline" "scope" "enabled"])
     (mkRenamedOptionModule ["vim" "visuals" "indentBlankline" "showEndOfLine"] ["vim" "visuals" "indentBlankline" "scope" "showEndOfLine"])
     (mkRemovedOptionModule ["vim" "visuals" "indentBlankline" "useTreesitter"] "`vim.visuals.indentBlankline.useTreesitter` has been removed upstream and can safely be removed from your configuration.")
   ];
@@ -115,6 +115,13 @@ in {
       };
 
       scope = {
+        enabled = mkOption {
+          description = "Highlight current scope from treesitter";
+          type = types.bool;
+          default = config.vim.treesitter.enable;
+          defaultText = literalExpression "config.vim.treesitter.enable";
+        };
+
         showEndOfLine = mkOption {
           description = ''
             Displays the end of line character set by [](#opt-vim.visuals.indentBlankline.eolChar) instead of the
@@ -123,13 +130,6 @@ in {
           type = types.bool;
           default = cfg.indentBlankline.eolChar != null;
           defaultText = literalExpression "config.vim.visuals.indentBlankline.eolChar != null";
-        };
-
-        showCurrContext = mkOption {
-          description = "Highlight current context from treesitter";
-          type = types.bool;
-          default = config.vim.treesitter.enable;
-          defaultText = literalExpression "config.vim.treesitter.enable";
         };
       };
     };

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -3,10 +3,16 @@
   lib,
   ...
 }: let
-  inherit (lib) mkEnableOption mkMappingOption mkOption types literalExpression;
+  inherit (lib) mkEnableOption mkMappingOption mkOption types literalExpression mkRenamedOptionModule mkRemovedOptionModule;
 
   cfg = config.vim.visuals;
 in {
+  imports = [
+    (mkRenamedOptionModule ["vim" "visuals" "indentBlankline" "showCurrContext"] ["vim" "visuals" "indentBlankline" "scope" "showCurrContext"])
+    (mkRenamedOptionModule ["vim" "visuals" "indentBlankline" "showEndOfLine"] ["vim" "visuals" "indentBlankline" "scope" "showEndOfLine"])
+    (mkRemovedOptionModule ["vim" "visuals" "indentBlankline" "useTreesitter"] "`vim.visuals.indentBlankline.useTreesitter` has been removed upstream and can safely be removed from your configuration.")
+  ];
+
   options.vim.visuals = {
     enable = mkEnableOption "Visual enhancements.";
 
@@ -60,6 +66,35 @@ in {
 
     indentBlankline = {
       enable = mkEnableOption "indentation guides [indent-blankline]";
+      debounce = mkOption {
+        type = types.int;
+        description = "Debounce time in milliseconds";
+        default = 200;
+      };
+
+      viewportBuffer = {
+        min = mkOption {
+          type = types.int;
+          description = "Number of lines above and below of what is currently
+            visible in the window";
+          default = 30;
+        };
+
+        max = mkOption {
+          type = types.int;
+          description = "Number of lines above and below of what is currently
+            visible in the window";
+          default = 500;
+        };
+      };
+
+      indent = {
+        char = mkOption {
+          type = types.str;
+          description = "Character for indentation line";
+          default = "│";
+        };
+      };
 
       listChar = mkOption {
         type = types.str;
@@ -79,28 +114,23 @@ in {
         default = "↴";
       };
 
-      showEndOfLine = mkOption {
-        description = ''
-          Displays the end of line character set by [](#opt-vim.visuals.indentBlankline.eolChar) instead of the
-          indent guide on line returns.
-        '';
-        type = types.bool;
-        default = cfg.indentBlankline.eolChar != null;
-        defaultText = literalExpression "config.vim.visuals.indentBlankline.eolChar != null";
-      };
+      scope = {
+        showEndOfLine = mkOption {
+          description = ''
+            Displays the end of line character set by [](#opt-vim.visuals.indentBlankline.eolChar) instead of the
+            indent guide on line returns.
+          '';
+          type = types.bool;
+          default = cfg.indentBlankline.eolChar != null;
+          defaultText = literalExpression "config.vim.visuals.indentBlankline.eolChar != null";
+        };
 
-      showCurrContext = mkOption {
-        description = "Highlight current context from treesitter";
-        type = types.bool;
-        default = config.vim.treesitter.enable;
-        defaultText = literalExpression "config.vim.treesitter.enable";
-      };
-
-      useTreesitter = mkOption {
-        description = "Use treesitter to calculate indentation when possible.";
-        type = types.bool;
-        default = config.vim.treesitter.enable;
-        defaultText = literalExpression "config.vim.treesitter.enable";
+        showCurrContext = mkOption {
+          description = "Highlight current context from treesitter";
+          type = types.bool;
+          default = config.vim.treesitter.enable;
+          defaultText = literalExpression "config.vim.treesitter.enable";
+        };
       };
     };
 


### PR DESCRIPTION
Updates indent-blankline to v3 and removes the workaround requiring `vim.wo.colorcolumn = "99999"` - reported to be fixed upstream in neovim.

I've renamed some of the module options, and I'd *really* like to use `lib.mkRemovedOptionModule` and `lib.mkRenamedOptionModule`, however, both of those cause the build system to assert the files they are defined in (wherever they are) are not actually modules.