### PR TITLE
utility/surround: Add mappings for nvim-surround

### DIFF
--- a/docs/release-notes/rl-0.5.adoc
+++ b/docs/release-notes/rl-0.5.adoc
@@ -69,3 +69,7 @@ https://github.com/jacekpoz[jacekpoz]:
 * Updated clangd to 16
 
 * Disabled `useSystemClipboard` by default
+
+https://github.com/ksonj[ksonj]:
+
+* Add support to change mappings to utility/surround

--- a/modules/utility/surround/config.nix
+++ b/modules/utility/surround/config.nix
@@ -6,14 +6,38 @@
 with lib;
 with builtins; let
   cfg = config.vim.utility.surround;
+  self = import ./surround.nix {inherit lib;};
+  mappingDefinitions = self.options.vim.utility.surround.mappings;
+  mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
-  config = mkIf (cfg.enable) {
-    vim.startPlugins = [
-      "nvim-surround"
-    ];
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = [
+        "nvim-surround"
+      ];
 
-    vim.luaConfigRC.surround = nvim.dag.entryAnywhere ''
-      require('nvim-surround').setup()
-    '';
+      luaConfigRC.surround = nvim.dag.entryAnywhere ''
+        require('nvim-surround').setup()
+      '';
+
+      maps = {
+        insert = mkMerge [
+          (mkSetBinding mappings.insert "<Plug>(nvim-surround-insert)")
+          (mkSetBinding mappings.insertLine "<Plug>(nvim-surround-insert-line)")
+        ];
+        normal = mkMerge [
+          (mkSetBinding mappings.normal "<Plug>(nvim-surround-normal)")
+          (mkSetBinding mappings.normalCur "<Plug>(nvim-surround-normal-cur)")
+          (mkSetBinding mappings.normalLine "<Plug>(nvim-surround-normal-line)")
+          (mkSetBinding mappings.normalCurLine "<Plug>(nvim-surround-normal-cur-line)")
+          (mkSetBinding mappings.delete "<Plug>(nvim-surround-delete)")
+          (mkSetBinding mappings.change "<Plug>(nvim-surround-change)")
+        ];
+        visualOnly = mkMerge [
+          (mkSetBinding mappings.visual "<Plug>(nvim-surround-visual)")
+          (mkSetBinding mappings.visualLine "<Plug>(nvim-surround-visual-line)")
+        ];
+      };
+    };
   };
 }

--- a/modules/utility/surround/config.nix
+++ b/modules/utility/surround/config.nix
@@ -6,7 +6,7 @@
 with lib;
 with builtins; let
   cfg = config.vim.utility.surround;
-  self = import ./surround.nix {inherit lib;};
+  self = import ./surround.nix {inherit lib config;};
   mappingDefinitions = self.options.vim.utility.surround.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
@@ -22,20 +22,20 @@ in {
 
       maps = {
         insert = mkMerge [
-          (mkSetBinding mappings.insert "<Plug>(nvim-surround-insert)")
-          (mkSetBinding mappings.insertLine "<Plug>(nvim-surround-insert-line)")
+          (mkIf (mappings.insert != null) (mkSetBinding mappings.insert "<Plug>(nvim-surround-insert)"))
+          (mkIf (mappings.insertLine != null) (mkSetBinding mappings.insertLine "<Plug>(nvim-surround-insert-line)"))
         ];
         normal = mkMerge [
-          (mkSetBinding mappings.normal "<Plug>(nvim-surround-normal)")
-          (mkSetBinding mappings.normalCur "<Plug>(nvim-surround-normal-cur)")
-          (mkSetBinding mappings.normalLine "<Plug>(nvim-surround-normal-line)")
-          (mkSetBinding mappings.normalCurLine "<Plug>(nvim-surround-normal-cur-line)")
-          (mkSetBinding mappings.delete "<Plug>(nvim-surround-delete)")
-          (mkSetBinding mappings.change "<Plug>(nvim-surround-change)")
+          (mkIf (mappings.normal != null) (mkSetBinding mappings.normal "<Plug>(nvim-surround-normal)"))
+          (mkIf (mappings.normalCur != null) (mkSetBinding mappings.normalCur "<Plug>(nvim-surround-normal-cur)"))
+          (mkIf (mappings.normalLine != null) (mkSetBinding mappings.normalLine "<Plug>(nvim-surround-normal-line)"))
+          (mkIf (mappings.normalCurLine != null) (mkSetBinding mappings.normalCurLine "<Plug>(nvim-surround-normal-cur-line)"))
+          (mkIf (mappings.delete != null) (mkSetBinding mappings.delete "<Plug>(nvim-surround-delete)"))
+          (mkIf (mappings.change != null) (mkSetBinding mappings.change "<Plug>(nvim-surround-change)"))
         ];
         visualOnly = mkMerge [
-          (mkSetBinding mappings.visual "<Plug>(nvim-surround-visual)")
-          (mkSetBinding mappings.visualLine "<Plug>(nvim-surround-visual-line)")
+          (mkIf (mappings.visual != null) (mkSetBinding mappings.visual "<Plug>(nvim-surround-visual)"))
+          (mkIf (mappings.visualLine != null) (mkSetBinding mappings.visualLine "<Plug>(nvim-surround-visual-line)"))
         ];
       };
     };

--- a/modules/utility/surround/surround.nix
+++ b/modules/utility/surround/surround.nix
@@ -3,5 +3,58 @@ with lib;
 with builtins; {
   options.vim.utility.surround = {
     enable = mkEnableOption "nvim-surround: add/change/delete surrounding delimiter pairs with ease";
+    mappings = {
+      insert = mkOption {
+        type = types.nullOr types.str;
+        default = "<C-g>s";
+        description = "Add surround character around the cursor";
+      };
+      insertLine = mkOption {
+        type = types.nullOr types.str;
+        default = "<C-g>S";
+        description = "Add surround character around the cursor on new lines";
+      };
+      normal = mkOption {
+        type = types.nullOr types.str;
+        default = "ys";
+        description = "Surround motion with character";
+      };
+      normalCur = mkOption {
+        type = types.nullOr types.str;
+        default = "yss";
+        description = "Surround motion with character on new lines";
+      };
+      normalLine = mkOption {
+        type = types.nullOr types.str;
+        default = "yS";
+        description = "Surround line with character";
+      };
+      normalCurLine = mkOption {
+        type = types.nullOr types.str;
+        default = "ySS";
+        description = "Surround line with character on new lines";
+      };
+      visual = mkOption {
+        type = types.nullOr types.str;
+        default = "S";
+        description = "Surround selection with character";
+      };
+      visualLine = mkOption {
+        type = types.nullOr types.str;
+        default = "gS";
+        description = "Surround selection with character on new lines";
+      };
+      delete = mkOption {
+        type = types.nullOr types.str;
+        default = "ds";
+        description = "Delete surrounding character";
+      };
+      change = mkOption {
+        type = types.nullOr types.str;
+        default = "cs";
+        description = "Change surrounding character";
+      };
+
+    };
   };
 }

--- a/modules/utility/surround/surround.nix
+++ b/modules/utility/surround/surround.nix
@@ -1,59 +1,88 @@
-{lib, ...}:
+{
+  lib,
+  config,
+  ...
+}:
 with lib;
 with builtins; {
   options.vim.utility.surround = {
-    enable = mkEnableOption "nvim-surround: add/change/delete surrounding delimiter pairs with ease";
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "nvim-surround: add/change/delete surrounding delimiter pairs with ease. Note that the default mappings deviate from upstreeam to avoid conflicts with nvim-leap.";
+    };
+    useVendoredKeybindings = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Use alternative set of keybindings that avoids conflicts with other popular plugins, e.g. nvim-leap";
+    };
     mappings = {
       insert = mkOption {
         type = types.nullOr types.str;
-        default = "<C-g>s";
+        default = "<C-g>z";
         description = "Add surround character around the cursor";
       };
       insertLine = mkOption {
         type = types.nullOr types.str;
-        default = "<C-g>S";
+        default = "<C-g>Z";
         description = "Add surround character around the cursor on new lines";
       };
       normal = mkOption {
         type = types.nullOr types.str;
-        default = "ys";
+        default = "gz";
         description = "Surround motion with character";
       };
       normalCur = mkOption {
         type = types.nullOr types.str;
-        default = "yss";
+        default = "gZ";
         description = "Surround motion with character on new lines";
       };
       normalLine = mkOption {
         type = types.nullOr types.str;
-        default = "yS";
+        default = "gzz";
         description = "Surround line with character";
       };
       normalCurLine = mkOption {
         type = types.nullOr types.str;
-        default = "ySS";
+        default = "gZZ";
         description = "Surround line with character on new lines";
       };
       visual = mkOption {
         type = types.nullOr types.str;
-        default = "S";
+        default = "gz";
         description = "Surround selection with character";
       };
       visualLine = mkOption {
         type = types.nullOr types.str;
-        default = "gS";
+        default = "gZ";
         description = "Surround selection with character on new lines";
       };
       delete = mkOption {
         type = types.nullOr types.str;
-        default = "ds";
+        default = "gzd";
         description = "Delete surrounding character";
       };
       change = mkOption {
         type = types.nullOr types.str;
-        default = "cs";
+        default = "gzr";
         description = "Change surrounding character";
       };
     };
+  };
+  config.vim.utility.surround = let
+    cfg = config.vim.utility.surround;
+  in {
+    mappings = mkIf (! cfg.useVendoredKeybindings) (mkDefault {
+      insert = null;
+      insertLine = null;
+      normal = null;
+      normalCur = null;
+      normalLine = null;
+      normalCurLine = null;
+      visual = null;
+      visualLine = null;
+      delete = null;
+      change = null;
+    });
   };
 }

--- a/modules/utility/surround/surround.nix
+++ b/modules/utility/surround/surround.nix
@@ -54,7 +54,6 @@ with builtins; {
         default = "cs";
         description = "Change surrounding character";
       };
-
     };
   };
 }


### PR DESCRIPTION
The default mappings for nvim-leap and nvim-surround conflict (i.e. nvim-surround uses `S` in visual mode). This change adds options to adapt the mappings for nvim-surround directly from the surround-module.