### PR TITLE
languages/python: add black-and-isort formatter

### DIFF
--- a/docs/release-notes/rl-0.5.adoc
+++ b/docs/release-notes/rl-0.5.adoc
@@ -73,3 +73,5 @@ https://github.com/jacekpoz[jacekpoz]:
 https://github.com/ksonj[ksonj]:
 
 * Add support to change mappings to utility/surround
+
+* Add black-and-isort python formatter

--- a/modules/languages/python.nix
+++ b/modules/languages/python.nix
@@ -40,7 +40,7 @@ with builtins; let
       '';
     };
     isort = {
-      package = pkgs.black;
+      package = pkgs.isort;
       nullConfig = ''
         table.insert(
           ls_sources,

--- a/modules/languages/python.nix
+++ b/modules/languages/python.nix
@@ -39,6 +39,34 @@ with builtins; let
         )
       '';
     };
+    isort = {
+      package = pkgs.black;
+      nullConfig = ''
+        table.insert(
+          ls_sources,
+          null_ls.builtins.formatting.isort.with({
+            command = "${cfg.format.package}/bin/isort",
+          })
+        )
+      '';
+    };
+    black-and-isort = {
+      package = pkgs.writeShellApplication {
+        name = "black";
+        text = ''
+          black --quiet - "$@" | isort --profile black -
+        '';
+        runtimeInputs = [pkgs.black pkgs.isort];
+      };
+      nullConfig = ''
+        table.insert(
+          ls_sources,
+          null_ls.builtins.formatting.black.with({
+            command = "${cfg.format.package}/bin/black",
+          })
+        )
+      '';
+    };
   };
 
   defaultDebugger = "debugpy";


### PR DESCRIPTION
Adds two additional formatters for python:

- isort, to only sort imports
- black-and-isort, which runs black + isort in a compatible manner