### PR TITLE
statusline/lualine: disable LSP status inside toggleterm buffer

### DIFF
--- a/modules/statusline/lualine/lualine.nix
+++ b/modules/statusline/lualine/lualine.nix
@@ -185,19 +185,29 @@ in {
           {
             {
               -- Lsp server name .
+
               function()
-                local msg = 'No Active Lsp'
                 local buf_ft = vim.api.nvim_buf_get_option(0, 'filetype')
+
+                -- Check if the current buffer type is "toggleterm"
+                if buf_ft == "toggleterm" then
+                  return ""
+                end
+
+                local msg = 'No Active Lsp'
                 local clients = vim.lsp.get_active_clients()
+
                 if next(clients) == nil then
                   return msg
                 end
+
                 for _, client in ipairs(clients) do
                   local filetypes = client.config.filetypes
                   if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
                     return client.name
                   end
                 end
+
                 return msg
               end,
               icon = ' ',

--- a/modules/statusline/lualine/lualine.nix
+++ b/modules/statusline/lualine/lualine.nix
@@ -187,7 +187,7 @@ in {
               -- Lsp server name .
 
               function()
-                local buf_ft = vim.api.nvim_buf_get_option(0, 'filetype')
+                local buf_ft = vim.api.nvim_get_option_value('filetype', {})
 
                 -- Check if the current buffer type is "toggleterm"
                 if buf_ft == "toggleterm" then


### PR DESCRIPTION
Disables LSP status inside the "toggleterm" buffer by returning "" if current buftype is toggleterm.