### PR TITLE
theme/oxocarbon: add oxocarbon theme module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1332,6 +1332,23 @@
         "type": "github"
       }
     },
+    "oxocarbon": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687168305,
+        "narHash": "sha256-2o++5aRDULfI35d+7psa6bk0eSXH2HwfuGjGtYGjR4w=",
+        "owner": "glyh",
+        "repo": "oxocarbon.nvim",
+        "rev": "7591d2e18df05374d612acba2b2573c7ff44dce4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "glyh",
+        "ref": "lualine-support",
+        "repo": "oxocarbon.nvim",
+        "type": "github"
+      }
+    },
     "plenary-nvim": {
       "flake": false,
       "locked": {
@@ -1492,6 +1509,7 @@
         "obsidian-nvim": "obsidian-nvim",
         "onedark": "onedark",
         "orgmode-nvim": "orgmode-nvim",
+        "oxocarbon": "oxocarbon",
         "plenary-nvim": "plenary-nvim",
         "presence-nvim": "presence-nvim",
         "project-nvim": "project-nvim",

--- a/flake.nix
+++ b/flake.nix
@@ -312,6 +312,11 @@
       flake = false;
     };
 
+    oxocarbon = {
+      url = "github:glyh/oxocarbon.nvim/lualine-support";
+      flake = false;
+    };
+
     # Rust crates
     crates-nvim = {
       url = "github:Saecki/crates.nvim";

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -42,6 +42,7 @@ with lib; let
     "onedark"
     "catppuccin"
     "dracula"
+    "oxocarbon"
     "minimap-vim"
     "dashboard-nvim"
     "alpha-nvim"

--- a/modules/statusline/lualine/supported_themes.nix
+++ b/modules/statusline/lualine/supported_themes.nix
@@ -2,4 +2,5 @@
   "tokyonight"
   "onedark"
   "catppuccin"
+  "oxocarbon"
 ]

--- a/modules/theme/supported_themes.nix
+++ b/modules/theme/supported_themes.nix
@@ -77,4 +77,19 @@
     '';
     styles = ["latte" "frappe" "macchiato" "mocha"];
   };
+
+  oxocarbon = {
+    setup = {
+      style ? "dark",
+      transparent ? false,
+    }: let
+      style' =
+        lib.warnIf (style == "light") "oxocarbon: light theme is not well-supported" style;
+    in ''
+      require('oxocarbon')
+      vim.opt.background = "${style'}"
+      vim.cmd.colorscheme = "oxocarbon"
+    '';
+    styles = ["dark" "light"];
+  };
 }


### PR DESCRIPTION
Adds fork of `oxocarbon.nvim` theme with lualine support. The provided lualine does not integrate with light theme and hence it is marked as 'not well-supported'.