### PR TITLE
plugins: Replace null-ls with none-ls

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -916,6 +916,22 @@
         "type": "github"
       }
     },
+    "none-ls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697600654,
+        "narHash": "sha256-dDMZEgT5uG31bEsLiX9r6MJlOJUdQyeTPJAeRcY2z7s=",
+        "owner": "nvimtools",
+        "repo": "none-ls.nvim",
+        "rev": "dc9b7e28f5573a1a2225ffb33893d23d3e052ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvimtools",
+        "repo": "none-ls.nvim",
+        "type": "github"
+      }
+    },
     "nui-nvim": {
       "flake": false,
       "locked": {
@@ -929,22 +945,6 @@
       "original": {
         "owner": "MunifTanjim",
         "repo": "nui.nvim",
-        "type": "github"
-      }
-    },
-    "null-ls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1688652536,
-        "narHash": "sha256-6KJtj9pbvBm6fOVpnyzO2fEVC+cVrw2XtZHOgq9ieIw=",
-        "owner": "jose-elias-alvarez",
-        "repo": "null-ls.nvim",
-        "rev": "db09b6c691def0038c456551e4e2772186449f35",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jose-elias-alvarez",
-        "repo": "null-ls.nvim",
         "type": "github"
       }
     },
@@ -1483,8 +1483,8 @@
         "nixpkgs": "nixpkgs",
         "nmd": "nmd",
         "noice-nvim": "noice-nvim",
+        "none-ls": "none-ls",
         "nui-nvim": "nui-nvim",
-        "null-ls": "null-ls",
         "nvim-autopairs": "nvim-autopairs",
         "nvim-bufferline-lua": "nvim-bufferline-lua",
         "nvim-cmp": "nvim-cmp",

--- a/flake.nix
+++ b/flake.nix
@@ -111,8 +111,8 @@
       flake = false;
     };
 
-    null-ls = {
-      url = "github:jose-elias-alvarez/null-ls.nvim";
+    none-ls = {
+      url = "github:nvimtools/none-ls.nvim";
       flake = false;
     };
 

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -31,7 +31,7 @@ with lib; let
     "vim-vsnip"
     "nvim-code-action-menu"
     "trouble"
-    "null-ls"
+    "none-ls"
     "which-key"
     "indent-blankline"
     "nvim-cursorline"

--- a/modules/lsp/null-ls/config.nix
+++ b/modules/lsp/null-ls/config.nix
@@ -11,7 +11,7 @@ in {
   config = mkIf cfg.null-ls.enable (mkMerge [
     {
       vim.lsp.enable = true;
-      vim.startPlugins = ["null-ls"];
+      vim.startPlugins = ["none-ls"];
 
       vim.luaConfigRC.null_ls-setup = nvim.dag.entryAnywhere ''
         local null_ls = require("null-ls")


### PR DESCRIPTION
null-ls is unmaintained as of August 2023 (see
https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1621). none-ls appears to be the accepted replacement fork.