### PR TITLE
fix enable option descriptions

### DIFF
--- a/modules/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/debugger/nvim-dap/nvim-dap.nix
@@ -1,10 +1,10 @@
 {lib, ...}:
 with lib; {
   options.vim.debugger.nvim-dap = {
-    enable = mkEnableOption "Enable debugging via nvim-dap";
+    enable = mkEnableOption "debugging via nvim-dap";
 
     ui = {
-      enable = mkEnableOption "Enable UI extension for nvim-dap";
+      enable = mkEnableOption "UI extension for nvim-dap";
       autoStart = mkOption {
         type = types.bool;
         default = true;

--- a/modules/filetree/nvimtree/nvimtree.nix
+++ b/modules/filetree/nvimtree/nvimtree.nix
@@ -207,7 +207,7 @@ with builtins; {
 
       type = types.submodule {
         options = {
-          enable = mkEnableOption "Enable diagnostics view in the signcolumn.";
+          enable = mkEnableOption "diagnostics view in the signcolumn.";
 
           debounceDelay = mkOption {
             description = "Idle milliseconds between diagnostic event and update.";

--- a/modules/languages/clang.nix
+++ b/modules/languages/clang.nix
@@ -89,7 +89,7 @@ in {
     };
 
     lsp = {
-      enable = mkEnableOption "Enable clang LSP support" // {default = config.vim.languages.enableLSP;};
+      enable = mkEnableOption "clang LSP support" // {default = config.vim.languages.enableLSP;};
 
       server = mkOption {
         description = "The clang LSP server to use";

--- a/modules/languages/dart/dart.nix
+++ b/modules/languages/dart/dart.nix
@@ -30,7 +30,7 @@ in {
     enable = mkEnableOption "Dart language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable Dart treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Dart treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = nvim.types.mkGrammarOption pkgs "dart";
     };
 

--- a/modules/languages/go.nix
+++ b/modules/languages/go.nix
@@ -70,13 +70,13 @@ in {
     enable = mkEnableOption "Go language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable Go treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Go treesitter" // {default = config.vim.languages.enableTreesitter;};
 
       package = nvim.types.mkGrammarOption pkgs "go";
     };
 
     lsp = {
-      enable = mkEnableOption "Enable Go LSP support" // {default = config.vim.languages.enableLSP;};
+      enable = mkEnableOption "Go LSP support" // {default = config.vim.languages.enableLSP;};
 
       server = mkOption {
         description = "Go LSP server to use";

--- a/modules/languages/java.nix
+++ b/modules/languages/java.nix
@@ -12,7 +12,7 @@ in {
     enable = mkEnableOption "Java language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable Java treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Java treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = nvim.types.mkGrammarOption pkgs "java";
     };
 

--- a/modules/languages/lua.nix
+++ b/modules/languages/lua.nix
@@ -11,11 +11,11 @@ in {
   options.vim.languages.lua = {
     enable = mkEnableOption "Lua language support";
     treesitter = {
-      enable = mkEnableOption "Enable Lua Treesitter support" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Lua Treesitter support" // {default = config.vim.languages.enableTreesitter;};
       package = nvim.types.mkGrammarOption pkgs "lua";
     };
     lsp = {
-      enable = mkEnableOption "Enable Lua LSP support via LuaLS" // {default = config.vim.languages.enableLSP;};
+      enable = mkEnableOption "Lua LSP support via LuaLS" // {default = config.vim.languages.enableLSP;};
 
       package = mkOption {
         description = "LuaLS package, or the command to run as a list of strings";
@@ -23,7 +23,7 @@ in {
         default = pkgs.lua-language-server;
       };
 
-      neodev.enable = mkEnableOption "Enable neodev.nvim integration, useful for neovim plugin developers";
+      neodev.enable = mkEnableOption "neodev.nvim integration, useful for neovim plugin developers";
     };
   };
 

--- a/modules/languages/nix.nix
+++ b/modules/languages/nix.nix
@@ -126,7 +126,7 @@ in {
     };
 
     lsp = {
-      enable = mkEnableOption "Enable Nix LSP support" // {default = config.vim.languages.enableLSP;};
+      enable = mkEnableOption "Nix LSP support" // {default = config.vim.languages.enableLSP;};
 
       server = mkOption {
         description = "Nix LSP server to use";
@@ -142,7 +142,7 @@ in {
     };
 
     format = {
-      enable = mkEnableOption "Enable Nix formatting" // {default = config.vim.languages.enableFormat;};
+      enable = mkEnableOption "Nix formatting" // {default = config.vim.languages.enableFormat;};
 
       type = mkOption {
         description = "Nix formatter to use";

--- a/modules/languages/php.nix
+++ b/modules/languages/php.nix
@@ -63,7 +63,7 @@ in {
     enable = mkEnableOption "PHP language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable PHP treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "PHP treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = nvim.types.mkGrammarOption pkgs "php";
     };
 

--- a/modules/languages/python.nix
+++ b/modules/languages/python.nix
@@ -136,7 +136,7 @@ in {
     enable = mkEnableOption "Python language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable Python treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Python treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = mkOption {
         description = "Python treesitter grammar to use";
         type = types.package;
@@ -145,7 +145,7 @@ in {
     };
 
     lsp = {
-      enable = mkEnableOption "Enable Python LSP support" // {default = config.vim.languages.enableLSP;};
+      enable = mkEnableOption "Python LSP support" // {default = config.vim.languages.enableLSP;};
 
       server = mkOption {
         description = "Python LSP server to use";
@@ -162,7 +162,7 @@ in {
     };
 
     format = {
-      enable = mkEnableOption "Enable Python formatting" // {default = config.vim.languages.enableFormat;};
+      enable = mkEnableOption "Python formatting" // {default = config.vim.languages.enableFormat;};
 
       type = mkOption {
         description = "Python formatter to use";

--- a/modules/languages/rust.nix
+++ b/modules/languages/rust.nix
@@ -12,7 +12,7 @@ in {
     enable = mkEnableOption "Rust language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable Rust treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Rust treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = nvim.types.mkGrammarOption pkgs "rust";
     };
 

--- a/modules/languages/sql.nix
+++ b/modules/languages/sql.nix
@@ -72,7 +72,7 @@ in {
     };
 
     treesitter = {
-      enable = mkEnableOption "Enable SQL treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "SQL treesitter" // {default = config.vim.languages.enableTreesitter;};
 
       package = mkOption {
         description = "SQL treesitter grammar to use";
@@ -82,7 +82,7 @@ in {
     };
 
     lsp = {
-      enable = mkEnableOption "Enable SQL LSP support" // {default = config.vim.languages.enableLSP;};
+      enable = mkEnableOption "SQL LSP support" // {default = config.vim.languages.enableLSP;};
 
       server = mkOption {
         description = "SQL LSP server to use";
@@ -99,7 +99,7 @@ in {
     };
 
     format = {
-      enable = mkEnableOption "Enable SQL formatting" // {default = config.vim.languages.enableFormat;};
+      enable = mkEnableOption "SQL formatting" // {default = config.vim.languages.enableFormat;};
 
       type = mkOption {
         description = "SQL formatter to use";
@@ -115,7 +115,7 @@ in {
     };
 
     extraDiagnostics = {
-      enable = mkEnableOption "Enable extra SQL diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+      enable = mkEnableOption "extra SQL diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
 
       types = lib.nvim.types.diagnostics {
         langDesc = "SQL";

--- a/modules/languages/svelte.nix
+++ b/modules/languages/svelte.nix
@@ -62,13 +62,13 @@ in {
     enable = mkEnableOption "Svelte language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable Svelte treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Svelte treesitter" // {default = config.vim.languages.enableTreesitter;};
 
       sveltePackage = nvim.types.mkGrammarOption pkgs "svelte";
     };
 
     lsp = {
-      enable = mkEnableOption "Enable Svelte LSP support" // {default = config.vim.languages.enableLSP;};
+      enable = mkEnableOption "Svelte LSP support" // {default = config.vim.languages.enableLSP;};
 
       server = mkOption {
         description = "Svelte LSP server to use";
@@ -85,7 +85,7 @@ in {
     };
 
     format = {
-      enable = mkEnableOption "Enable Svelte formatting" // {default = config.vim.languages.enableFormat;};
+      enable = mkEnableOption "Svelte formatting" // {default = config.vim.languages.enableFormat;};
 
       type = mkOption {
         description = "Svelte formatter to use";
@@ -101,7 +101,7 @@ in {
     };
 
     extraDiagnostics = {
-      enable = mkEnableOption "Enable extra Svelte diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+      enable = mkEnableOption "extra Svelte diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
 
       types = lib.nvim.types.diagnostics {
         langDesc = "Svelte";

--- a/modules/languages/ts.nix
+++ b/modules/languages/ts.nix
@@ -88,13 +88,13 @@ in {
     enable = mkEnableOption "Typescript/Javascript language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable Typescript/Javascript treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Typescript/Javascript treesitter" // {default = config.vim.languages.enableTreesitter;};
       tsPackage = nvim.types.mkGrammarOption pkgs "tsx";
       jsPackage = nvim.types.mkGrammarOption pkgs "javascript";
     };
 
     lsp = {
-      enable = mkEnableOption "Enable Typescript/Javascript LSP support" // {default = config.vim.languages.enableLSP;};
+      enable = mkEnableOption "Typescript/Javascript LSP support" // {default = config.vim.languages.enableLSP;};
 
       server = mkOption {
         description = "Typescript/Javascript LSP server to use";
@@ -111,7 +111,7 @@ in {
     };
 
     format = {
-      enable = mkEnableOption "Enable Typescript/Javascript formatting" // {default = config.vim.languages.enableFormat;};
+      enable = mkEnableOption "Typescript/Javascript formatting" // {default = config.vim.languages.enableFormat;};
 
       type = mkOption {
         description = "Typescript/Javascript formatter to use";
@@ -127,7 +127,7 @@ in {
     };
 
     extraDiagnostics = {
-      enable = mkEnableOption "Enable extra Typescript/Javascript diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+      enable = mkEnableOption "extra Typescript/Javascript diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
 
       types = lib.nvim.types.diagnostics {
         langDesc = "Typescript/Javascript";

--- a/modules/languages/zig.nix
+++ b/modules/languages/zig.nix
@@ -12,7 +12,7 @@ in {
     enable = mkEnableOption "Zig language support";
 
     treesitter = {
-      enable = mkEnableOption "Enable Zig treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Zig treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = nvim.types.mkGrammarOption pkgs "zig";
     };
 

--- a/modules/lsp/nvim-code-action-menu/nvim-code-action-menu.nix
+++ b/modules/lsp/nvim-code-action-menu/nvim-code-action-menu.nix
@@ -2,7 +2,7 @@
 with lib; {
   options.vim.lsp = {
     nvimCodeActionMenu = {
-      enable = mkEnableOption "Enable nvim code action menu";
+      enable = mkEnableOption "nvim code action menu";
 
       show = {
         details = mkEnableOption "Show details" // {default = true;};

--- a/modules/lsp/trouble/trouble.nix
+++ b/modules/lsp/trouble/trouble.nix
@@ -2,7 +2,7 @@
 with lib; {
   options.vim.lsp = {
     trouble = {
-      enable = mkEnableOption "Enable trouble diagnostics viewer";
+      enable = mkEnableOption "trouble diagnostics viewer";
 
       mappings = {
         toggle = mkMappingOption "Toggle trouble [trouble]" "<leader>xx";

--- a/modules/notes/orgmode/orgmode.nix
+++ b/modules/notes/orgmode/orgmode.nix
@@ -22,7 +22,7 @@ with builtins; {
     };
 
     treesitter = {
-      enable = mkEnableOption "Enable Orgmode treesitter" // {default = config.vim.languages.enableTreesitter;};
+      enable = mkEnableOption "Orgmode treesitter" // {default = config.vim.languages.enableTreesitter;};
 
       orgPackage = nvim.types.mkGrammarOption pkgs "org";
     };

--- a/modules/projects/project-nvim/project-nvim.nix
+++ b/modules/projects/project-nvim/project-nvim.nix
@@ -6,7 +6,7 @@
 with lib;
 with builtins; {
   options.vim.projects.project-nvim = {
-    enable = mkEnableOption "Enable project-nvim for project management";
+    enable = mkEnableOption "project-nvim for project management";
 
     manualMode = mkOption {
       type = types.bool;

--- a/modules/terminal/toggleterm/toggleterm.nix
+++ b/modules/terminal/toggleterm/toggleterm.nix
@@ -7,7 +7,7 @@
 with lib;
 with builtins; {
   options.vim.terminal.toggleterm = {
-    enable = mkEnableOption "Enable toggleterm as a replacement to built-in terminal command";
+    enable = mkEnableOption "toggleterm as a replacement to built-in terminal command";
     mappings = {
       open = mkOption {
         type = types.nullOr types.str;

--- a/modules/ui/borders/borders.nix
+++ b/modules/ui/borders/borders.nix
@@ -23,7 +23,7 @@ in {
     # TODO: make per-plugin borders configurable
     plugins = let
       mkPluginStyleOption = name: {
-        enable = mkEnableOption "whether to enable borders for the ${name} plugin" // {default = cfg.enable;};
+        enable = mkEnableOption "borders for the ${name} plugin" // {default = cfg.enable;};
 
         style = mkOption {
           type = types.enum (defaultStyles ++ lib.optionals (name != "which-key") ["shadow"]);

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -12,12 +12,12 @@ in {
 
     nvimWebDevicons.enable = mkEnableOption "dev icons. Required for certain plugins [nvim-web-devicons].";
 
-    scrollBar.enable = mkEnableOption "Enable scrollbar [scrollbar.nvim]";
+    scrollBar.enable = mkEnableOption "scrollbar [scrollbar.nvim]";
 
-    smoothScroll.enable = mkEnableOption "Enable smooth scrolling [cinnamon-nvim]";
+    smoothScroll.enable = mkEnableOption "smooth scrolling [cinnamon-nvim]";
 
     cellularAutomaton = {
-      enable = mkEnableOption "Enable cellular automaton [cellular-automaton]";
+      enable = mkEnableOption "cellular automaton [cellular-automaton]";
 
       mappings = {
         makeItRain = mkMappingOption "Make it rain [cellular-automaton]" "<leader>fml";
@@ -25,7 +25,7 @@ in {
     };
 
     fidget-nvim = {
-      enable = mkEnableOption "Enable nvim LSP UI element [fidget-nvim]";
+      enable = mkEnableOption "nvim LSP UI element [fidget-nvim]";
 
       align = {
         bottom = mkOption {
@@ -59,7 +59,7 @@ in {
     };
 
     indentBlankline = {
-      enable = mkEnableOption "Enable indentation guides [indent-blankline]";
+      enable = mkEnableOption "indentation guides [indent-blankline]";
 
       listChar = mkOption {
         type = types.str;


### PR DESCRIPTION
I noticed a few oddly phrased descriptions for enable options in the docs.

mkEnableOption already adds the phrase "Whether to enable ..." to the beginning of the option description, such that the string argument should only be "thing to be enabled"

Also, sorry for the PR spam :grimacing: 