### PR TITLE
statusline/lualine: extensible sections

### DIFF
--- a/docs/release-notes/rl-0.5.adoc
+++ b/docs/release-notes/rl-0.5.adoc
@@ -89,3 +89,7 @@ https://github.com/ksonj[ksonj]:
 * Removed redundant "Enable ..." in `mkEnableOption` descriptions
 
 * Add options to modify LSP key bindings and add proper whichkey descriptions
+
+* Changed type of `statusline.lualine.activeSection` and `statusline.lualine.inactiveSection` from `attrsOf str` to `attrsOf (listOf str)`
+
+* Added `statusline.lualine.extraActiveSection` and `statusline.lualine.extraInactiveSection`

--- a/lib/lua.nix
+++ b/lib/lua.nix
@@ -44,4 +44,6 @@
       )
     )
     + " }";
+  # Convert a list of lua expressions to a lua table. The difference to listToLuaTable is that the elements here are expected to be lua expressions already, whereas listToLuaTable converts from nix types to lua first
+  luaTable = items: ''{${builtins.concatStringsSep "," items}}'';
 }

--- a/modules/statusline/lualine/config.nix
+++ b/modules/statusline/lualine/config.nix
@@ -5,6 +5,7 @@
 }:
 with lib; let
   cfg = config.vim.statusline.lualine;
+  luaTable = items: ''{${builtins.concatStringsSep "," items}}'';
 in {
   config = (mkIf cfg.enable) {
     vim.startPlugins = [
@@ -32,21 +33,21 @@ in {
         },
         -- active sections
         sections = {
-          lualine_a = ${cfg.activeSection.a},
-          lualine_b = ${cfg.activeSection.b},
-          lualine_c = ${cfg.activeSection.c},
-          lualine_x = ${cfg.activeSection.x},
-          lualine_y = ${cfg.activeSection.y},
-          lualine_z = ${cfg.activeSection.z},
+          lualine_a = ${luaTable (cfg.activeSection.a ++ cfg.extraActiveSection.a)},
+          lualine_b = ${luaTable (cfg.activeSection.b ++ cfg.extraActiveSection.b)},
+          lualine_c = ${luaTable (cfg.activeSection.c ++ cfg.extraActiveSection.c)},
+          lualine_x = ${luaTable (cfg.activeSection.x ++ cfg.extraActiveSection.x)},
+          lualine_y = ${luaTable (cfg.activeSection.y ++ cfg.extraActiveSection.y)},
+          lualine_z = ${luaTable (cfg.activeSection.z ++ cfg.extraActiveSection.z)},
         },
         --
         inactive_sections = {
-          lualine_a = ${cfg.inactiveSection.a},
-          lualine_b = ${cfg.inactiveSection.b},
-          lualine_c = ${cfg.inactiveSection.c},
-          lualine_x = ${cfg.inactiveSection.x},
-          lualine_y = ${cfg.inactiveSection.y},
-          lualine_z = ${cfg.inactiveSection.z},
+          lualine_a = ${luaTable (cfg.inactiveSection.a ++ cfg.extraInactiveSection.a)},
+          lualine_b = ${luaTable (cfg.inactiveSection.b ++ cfg.extraInactiveSection.b)},
+          lualine_c = ${luaTable (cfg.inactiveSection.c ++ cfg.extraInactiveSection.c)},
+          lualine_x = ${luaTable (cfg.inactiveSection.x ++ cfg.extraInactiveSection.x)},
+          lualine_y = ${luaTable (cfg.inactiveSection.y ++ cfg.extraInactiveSection.y)},
+          lualine_z = ${luaTable (cfg.inactiveSection.z ++ cfg.extraInactiveSection.z)},
         },
         tabline = {},
 

--- a/modules/statusline/lualine/config.nix
+++ b/modules/statusline/lualine/config.nix
@@ -5,7 +5,7 @@
 }:
 with lib; let
   cfg = config.vim.statusline.lualine;
-  luaTable = items: ''{${builtins.concatStringsSep "," items}}'';
+  inherit (nvim.lua) luaTable;
 in {
   config = (mkIf cfg.enable) {
     vim.startPlugins = [

--- a/modules/statusline/lualine/lualine.nix
+++ b/modules/statusline/lualine/lualine.nix
@@ -117,7 +117,7 @@ in {
 
     activeSection = {
       a = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "active config for: | (A) | B | C       X | Y | Z |";
         default = [
           ''
@@ -134,7 +134,7 @@ in {
       };
 
       b = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "active config for: | A | (B) | C       X | Y | Z |";
         default = [
           ''
@@ -157,7 +157,7 @@ in {
       };
 
       c = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "active config for: | A | B | (C)       X | Y | Z |";
         default = [
           ''
@@ -181,7 +181,7 @@ in {
       };
 
       x = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "active config for: | A | B | C       (X) | Y | Z |";
         default = [
           ''
@@ -239,7 +239,7 @@ in {
       };
 
       y = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "active config for: | A | B | C       X | (Y) | Z |";
         default = [
           ''
@@ -261,7 +261,7 @@ in {
       };
 
       z = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "active config for: | A | B | C       X | Y | (Z) |";
         default = [
           ''
@@ -293,32 +293,32 @@ in {
     };
     extraActiveSection = {
       a = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for activeSection.a";
         default = [];
       };
       b = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for activeSection.b";
         default = [];
       };
       c = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for activeSection.c";
         default = [];
       };
       x = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for activeSection.x";
         default = [];
       };
       y = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for activeSection.y";
         default = [];
       };
       z = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for activeSection.z";
         default = [];
       };
@@ -326,69 +326,69 @@ in {
 
     inactiveSection = {
       a = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "inactive config for: | (A) | B | C       X | Y | Z |";
         default = [];
       };
 
       b = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "inactive config for: | A | (B) | C       X | Y | Z |";
         default = [];
       };
 
       c = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "inactive config for: | A | B | (C)       X | Y | Z |";
         default = ["'filename'"];
       };
 
       x = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "inactive config for: | A | B | C       (X) | Y | Z |";
         default = ["'location'"];
       };
 
       y = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "inactive config for: | A | B | C       X | (Y) | Z |";
         default = [];
       };
 
       z = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "inactive config for: | A | B | C       X | Y | (Z) |";
         default = [];
       };
     };
     extraInactiveSection = {
       a = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for inactiveSection.a";
         default = [];
       };
       b = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for inactiveSection.b";
         default = [];
       };
       c = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for inactiveSection.c";
         default = [];
       };
       x = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for inactiveSection.x";
         default = [];
       };
       y = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for inactiveSection.y";
         default = [];
       };
       z = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf str;
         description = "Extra entries for inactiveSection.z";
         default = [];
       };

--- a/modules/statusline/lualine/lualine.nix
+++ b/modules/statusline/lualine/lualine.nix
@@ -117,10 +117,10 @@ in {
 
     activeSection = {
       a = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "active config for: | (A) | B | C       X | Y | Z |";
-        default = ''
-          {
+        default = [
+          ''
             {
               "mode",
               icons_enabled = true,
@@ -128,37 +128,39 @@ in {
                 left = '▎',
                 right = ''
               },
-            },
-          }
-        '';
+            }
+          ''
+        ];
       };
 
       b = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "active config for: | A | (B) | C       X | Y | Z |";
-        default = ''
-          {
+        default = [
+          ''
             {
               "filetype",
               colored = true,
               icon_only = true,
               icon = { align = 'left' },
               color = {bg='${colorPuccin}', fg='lavender'},
-            },
+            }
+          ''
+          ''
             {
               "filename",
               color = {bg='${colorPuccin}'},
               symbols = {modified = '', readonly = ''},
-            },
-          }
-        '';
+            }
+          ''
+        ];
       };
 
       c = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "active config for: | A | B | (C)       X | Y | Z |";
-        default = ''
-          {
+        default = [
+          ''
             {
               "diff",
               colored = false,
@@ -173,16 +175,16 @@ in {
                 bg='${colorPuccin}',
                 fg='lavender'
               },
-            },
-          }
-        '';
+            }
+          ''
+        ];
       };
 
       x = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "active config for: | A | B | C       (X) | Y | Z |";
-        default = ''
-          {
+        default = [
+          ''
             {
               -- Lsp server name
               function()
@@ -218,7 +220,9 @@ in {
               end,
               icon = ' ',
               color = {bg='${colorPuccin}', fg='lavender'},
-            },
+            }
+          ''
+          ''
             {
               "diagnostics",
               sources = {'nvim_lsp', 'nvim_diagnostic', 'coc'},
@@ -229,45 +233,51 @@ in {
                 color_warn = { fg = 'yellow' },
                 color_info = { fg = 'cyan' },
               },
-            },
-          }
-        '';
+            }
+          ''
+        ];
       };
 
       y = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "active config for: | A | B | C       X | (Y) | Z |";
-        default = ''
-          {
+        default = [
+          ''
             {
               'searchcount',
               maxcount = 999,
               timeout = 120,
               color = {bg='${colorPuccin}', fg='lavender'}
-            },
+            }
+          ''
+          ''
             {
               "branch",
               icon = ' •',
               color = {bg='${colorPuccin}', fg='lavender'},
-            },
-          }
-        '';
+            }
+          ''
+        ];
       };
 
       z = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "active config for: | A | B | C       X | Y | (Z) |";
-        default = ''
-          {
+        default = [
+          ''
             {
               "progress",
               separator = {
                 left = '',
               },
-            },
+            }
+          ''
+          ''
             {
               "location",
-            },
+            }
+          ''
+          ''
             {
               "fileformat",
               color = {fg='black'},
@@ -276,47 +286,111 @@ in {
                 dos = '',  -- e70f
                 mac = '',  -- e711
               },
-            },
-          }
-        '';
+            }
+          ''
+        ];
+      };
+    };
+    extraActiveSection = {
+      a = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for activeSection.a";
+        default = [];
+      };
+      b = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for activeSection.b";
+        default = [];
+      };
+      c = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for activeSection.c";
+        default = [];
+      };
+      x = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for activeSection.x";
+        default = [];
+      };
+      y = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for activeSection.y";
+        default = [];
+      };
+      z = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for activeSection.z";
+        default = [];
       };
     };
 
     inactiveSection = {
       a = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "inactive config for: | (A) | B | C       X | Y | Z |";
-        default = "{}";
+        default = [];
       };
 
       b = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "inactive config for: | A | (B) | C       X | Y | Z |";
-        default = "{}";
+        default = [];
       };
 
       c = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "inactive config for: | A | B | (C)       X | Y | Z |";
-        default = "{'filename'}";
+        default = ["'filename'"];
       };
 
       x = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "inactive config for: | A | B | C       (X) | Y | Z |";
-        default = "{'location'}";
+        default = ["'location'"];
       };
 
       y = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "inactive config for: | A | B | C       X | (Y) | Z |";
-        default = "{}";
+        default = [];
       };
 
       z = mkOption {
-        type = types.str;
+        type = types.listOf types.str;
         description = "inactive config for: | A | B | C       X | Y | (Z) |";
-        default = "{}";
+        default = [];
+      };
+    };
+    extraInactiveSection = {
+      a = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for inactiveSection.a";
+        default = [];
+      };
+      b = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for inactiveSection.b";
+        default = [];
+      };
+      c = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for inactiveSection.c";
+        default = [];
+      };
+      x = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for inactiveSection.x";
+        default = [];
+      };
+      y = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for inactiveSection.y";
+        default = [];
+      };
+      z = mkOption {
+        type = types.listOf types.str;
+        description = "Extra entries for inactiveSection.z";
+        default = [];
       };
     };
   };


### PR DESCRIPTION
I have a usecase where I need to add an additional source to a section in the statusline. Since repeating and then extending the current defaults isn't very convenient, I've changed the type of `activeSection`s and `inactiveSection`s attributes to `listOf str`, added `extraActiveSection` and `extraInactiveSection` of the same type and then create a lua table from the concatentation of both settings in the config.

I immediately see two issues with this:

1. I am breaking existing configurations that customize the lualine sections
2. Having a nix-list of lua-values is a bit odd. Eg. adding a string would look like ``["'some_string'"]` :shrug: 

I'm not sure if (1.) is a problem. You're on 0.x still so I assume it's justifiable, but I'm of course willing to adapt this PR if you prefer a proper deprecation process or to keep the existing types.

For (2.) I think this somewhat is the nature of Nix but again I am willing to explore alternatives.