### PR TITLE
modules/lsp: add nvim-docs-view

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -38,6 +38,7 @@ inputs: let
         trouble.enable = true;
         lspSignature.enable = true;
         lsplines.enable = isMaximal;
+        nvim-docs-view.enable = isMaximal;
       };
 
       vim.debugger = {

--- a/docs/release-notes/rl-0.5.adoc
+++ b/docs/release-notes/rl-0.5.adoc
@@ -72,6 +72,8 @@ https://github.com/notashelf[notashelf]:
 
 * Disabled Lualine LSP status indicator for toggleterm buffer
 
+* Added `nvim-docs-view`, a plugin to display lsp hover documentation in a side panel
+
 https://github.com/jacekpoz[jacekpoz]:
 
 * Fixed scrollOffset not being used

--- a/flake.lock
+++ b/flake.lock
@@ -1108,6 +1108,22 @@
         "type": "github"
       }
     },
+    "nvim-docs-view": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697737319,
+        "narHash": "sha256-EmQbnleqxE+VHO5bMI9U/gMpwbJbPdNhrEWE7357MCE=",
+        "owner": "amrbashir",
+        "repo": "nvim-docs-view",
+        "rev": "74a5e989e3fdcfd9418bb9dfec0ace308e00a5a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "amrbashir",
+        "repo": "nvim-docs-view",
+        "type": "github"
+      }
+    },
     "nvim-lightbulb": {
       "flake": false,
       "locked": {
@@ -1511,6 +1527,7 @@
         "nvim-cursorline": "nvim-cursorline",
         "nvim-dap": "nvim-dap",
         "nvim-dap-ui": "nvim-dap-ui",
+        "nvim-docs-view": "nvim-docs-view",
         "nvim-lightbulb": "nvim-lightbulb",
         "nvim-lspconfig": "nvim-lspconfig",
         "nvim-navbuddy": "nvim-navbuddy",

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,12 @@
       flake = false;
     };
 
+    nvim-docs-view = {
+      url = "github:amrbashir/nvim-docs-view";
+      flake = false;
+    };
+
+    # language support
     sqls-nvim = {
       url = "github:nanotee/sqls.nvim";
       flake = false;
@@ -144,6 +150,17 @@
     elixir-tools = {
       url = "github:elixir-tools/elixir-tools.nvim";
       flake = false;
+    };
+
+    glow-nvim = {
+      url = "github:ellisonleao/glow.nvim";
+      flake = false;
+    };
+
+    # Tidal cycles
+    tidalcycles = {
+      url = "github:mitchmindtree/tidalcycles.nix";
+      inputs.vim-tidal-src.url = "github:tidalcycles/vim-tidal";
     };
 
     # Copying/Registers
@@ -371,18 +388,6 @@
     highlight-undo = {
       url = "github:tzachar/highlight-undo.nvim";
       flake = false;
-    };
-
-    # Markdown
-    glow-nvim = {
-      url = "github:ellisonleao/glow.nvim";
-      flake = false;
-    };
-
-    # Tidal cycles
-    tidalcycles = {
-      url = "github:mitchmindtree/tidalcycles.nix";
-      inputs.vim-tidal-src.url = "github:tidalcycles/vim-tidal";
     };
 
     # Minimap

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -95,6 +95,7 @@ with lib; let
     "lsp-lines"
     "vim-dirtytalk"
     "highlight-undo"
+    "nvim-docs-view"
   ];
   # You can either use the name of the plugin or a package.
   pluginType = with types;

--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -16,5 +16,6 @@ _: {
     ./lightbulb
     ./lspkind
     ./lsplines
+    ./nvim-docs-view
   ];
 }

--- a/modules/lsp/nvim-docs-view/config.nix
+++ b/modules/lsp/nvim-docs-view/config.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib) mkIf nvim;
+  inherit (builtins) toString;
+
+  cfg = config.vim.lsp.nvim-docs-view;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      lsp.enable = true;
+      startPlugins = ["nvim-docs-view"];
+
+      luaConfigRC.nvim-docs-view = nvim.dag.entryAnywhere ''
+        require("docs-view").setup {
+          position = "${cfg.position}",
+          width = ${toString cfg.width},
+          height = ${toString cfg.height},
+          update_mode = "${cfg.updateMode}",
+        }
+      '';
+    };
+  };
+}

--- a/modules/lsp/nvim-docs-view/default.nix
+++ b/modules/lsp/nvim-docs-view/default.nix
@@ -1,0 +1,6 @@
+_: {
+  imports = [
+    ./config.nix
+    ./nvim-docs-view.nix
+  ];
+}

--- a/modules/lsp/nvim-docs-view/nvim-docs-view.nix
+++ b/modules/lsp/nvim-docs-view/nvim-docs-view.nix
@@ -1,0 +1,41 @@
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
+  options.vim.lsp.nvim-docs-view = {
+    enable = mkEnableOption "nvim-docs-view, for displaying lsp hover documentation in a side panel.";
+
+    position = mkOption {
+      type = types.enum ["left" "right" "top" "bottom"];
+      default = "right";
+      description = ''
+        Where to open the docs view panel
+      '';
+    };
+
+    height = mkOption {
+      type = types.int;
+      default = 10;
+      description = ''
+        Height of the docs view panel if the position is set to either top or bottom
+      '';
+    };
+
+    width = mkOption {
+      type = types.int;
+      default = 60;
+      description = ''
+        Width of the docs view panel if the position is set to either left or right
+      '';
+    };
+
+    updateMode = mkOption {
+      type = types.enum ["auto" "manual"];
+      default = "auto";
+      description = ''
+        Determines the mechanism used to update the docs view panel content.
+        - If auto, the content will update upon cursor move.
+        - If manual, the content will only update once :DocsViewUpdate is called
+      '';
+    };
+  };
+}


### PR DESCRIPTION
A neovim plugin to display LSP hover documentation in a side panel, pretty similar to the VSCode extension [Docs View](https://marketplace.visualstudio.com/items?itemName=bierner.docs-view)