### PR TITLE
treewide: move from 'with lib' to 'inherit (lib) ...'

### DIFF
--- a/modules/assistant/copilot/config.nix
+++ b/modules/assistant/copilot/config.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim mkLuaBinding mkMerge;
+
   cfg = config.vim.assistant.copilot;
 
   wrapPanelBinding = luaFunction: key: ''

--- a/modules/assistant/copilot/copilot.nix
+++ b/modules/assistant/copilot/copilot.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+
   cfg = config.vim.assistant.copilot;
 in {
   options.vim.assistant.copilot = {

--- a/modules/assistant/tabnine/config.nix
+++ b/modules/assistant/tabnine/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf mkMerge mkExprBinding boolToString nvim;
+
   cfg = config.vim.assistant.tabnine;
 in {
   config = mkIf cfg.enable {

--- a/modules/assistant/tabnine/tabnine.nix
+++ b/modules/assistant/tabnine/tabnine.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types mkMappingOption;
+in {
   options.vim.assistant.tabnine = {
     enable = mkEnableOption "Tabnine assistant";
 

--- a/modules/autopairs/nvim-autopairs/config.nix
+++ b/modules/autopairs/nvim-autopairs/config.nix
@@ -2,9 +2,9 @@
   lib,
   config,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim optionalString boolToString;
+
   cfg = config.vim.autopairs;
 in {
   config =

--- a/modules/autopairs/nvim-autopairs/nvim-autopairs.nix
+++ b/modules/autopairs/nvim-autopairs/nvim-autopairs.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim = {
     autopairs = {
       enable = mkEnableOption "autopairs" // {default = false;};

--- a/modules/comments/comment-nvim/comment-nvim.nix
+++ b/modules/comments/comment-nvim/comment-nvim.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkMappingOption;
+in {
   options.vim.comments.comment-nvim = {
     enable = mkEnableOption "smart and powerful comment plugin for neovim comment-nvim";
 

--- a/modules/comments/comment-nvim/config.nix
+++ b/modules/comments/comment-nvim/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf mkMerge mkExprBinding mkBinding nvim;
+
   cfg = config.vim.comments.comment-nvim;
   self = import ./comment-nvim.nix {
     inherit lib;

--- a/modules/completion/nvim-cmp/config.nix
+++ b/modules/completion/nvim-cmp/config.nix
@@ -2,9 +2,9 @@
   lib,
   config,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings concatMapStringsSep attrNames concatStringsSep mapAttrsToList nvim mkIf mkSetLuaBinding mkMerge optionalString;
+
   cfg = config.vim.autocomplete;
   lspkindEnabled = config.vim.lsp.enable && config.vim.lsp.lspkind.enable;
 

--- a/modules/completion/nvim-cmp/nvim-cmp.nix
+++ b/modules/completion/nvim-cmp/nvim-cmp.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkMappingOption mkOption types;
+in {
   options.vim = {
     autocomplete = {
       enable = mkEnableOption "enable autocomplete" // {default = false;};

--- a/modules/core/default.nix
+++ b/modules/core/default.nix
@@ -7,6 +7,7 @@ with builtins; let
   inherit (lib) mkOption types mapAttrsFlatten filterAttrs optionalString getAttrs literalExpression;
   inherit (lib) nvim;
   inherit (nvim.lua) toLuaObject;
+  inherit (nvim.vim) valToVim;
 
   cfg = config.vim;
 

--- a/modules/dashboard/alpha/alpha.nix
+++ b/modules/dashboard/alpha/alpha.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.dashboard.alpha = {
     enable = mkEnableOption "dashboard via alpha.nvim";
   };

--- a/modules/dashboard/alpha/config.nix
+++ b/modules/dashboard/alpha/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.dashboard.alpha;
 in {
   config = mkIf cfg.enable {

--- a/modules/dashboard/dashboard-nvim/config.nix
+++ b/modules/dashboard/dashboard-nvim/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.dashboard.dashboard-nvim;
 in {
   config = mkIf cfg.enable {

--- a/modules/dashboard/dashboard-nvim/dashboard-nvim.nix
+++ b/modules/dashboard/dashboard-nvim/dashboard-nvim.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.dashboard.dashboard-nvim = {
     enable = mkEnableOption "dashboard via dashboard.nvim";
   };

--- a/modules/dashboard/startify/config.nix
+++ b/modules/dashboard/startify/config.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with builtins;
-with lib; let
+}: let
+  inherit (lib) mkIf;
+
   cfg = config.vim.dashboard.startify;
 
   mkVimBool = val:

--- a/modules/dashboard/startify/startify.nix
+++ b/modules/dashboard/startify/startify.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with builtins;
-with lib; {
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.dashboard.startify = {
     enable = mkEnableOption "dashboard via vim-startify";
 

--- a/modules/debugger/nvim-dap/config.nix
+++ b/modules/debugger/nvim-dap/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkMerge mkIf mapAttrs nvim mkSetLuaBinding optionalString;
+
   cfg = config.vim.debugger.nvim-dap;
   self = import ./nvim-dap.nix {
     inherit lib;

--- a/modules/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/debugger/nvim-dap/nvim-dap.nix
@@ -1,5 +1,6 @@
-{lib, ...}:
-with lib; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types mkMappingOption;
+in {
   options.vim.debugger.nvim-dap = {
     enable = mkEnableOption "debugging via nvim-dap";
 

--- a/modules/filetree/nvimtree/config.nix
+++ b/modules/filetree/nvimtree/config.nix
@@ -3,9 +3,9 @@
   lib,
   pkgs,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf mkMerge mkBinding nvim boolToString;
+
   cfg = config.vim.filetree.nvimTree;
   self = import ./nvimtree.nix {
     inherit pkgs;

--- a/modules/filetree/nvimtree/nvimtree.nix
+++ b/modules/filetree/nvimtree/nvimtree.nix
@@ -2,9 +2,9 @@
   pkgs,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types literalExpression;
+in {
   options.vim.filetree.nvimTree = {
     enable = mkEnableOption "filetree via nvim-tree.lua";
 

--- a/modules/git/config.nix
+++ b/modules/git/config.nix
@@ -2,9 +2,8 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkIf mkMerge mkSetExprBinding toJSON mkSetLuaBinding nvim;
   cfg = config.vim.git;
 
   self = import ./git.nix {inherit lib;};
@@ -20,7 +19,7 @@ in {
         vim.maps.normal = mkMerge [
           (mkSetExprBinding gsMappings.nextHunk ''
             function()
-              if vim.wo.diff then return ${toJSON gsMappings.nextHunk.value} end
+              if vim.wo.diff then return ${builtins.toJSON gsMappings.nextHunk.value} end
 
               vim.schedule(function() package.loaded.gitsigns.next_hunk() end)
 
@@ -29,7 +28,7 @@ in {
           '')
           (mkSetExprBinding gsMappings.previousHunk ''
             function()
-              if vim.wo.diff then return ${toJSON gsMappings.previousHunk.value} end
+              if vim.wo.diff then return ${builtins.toJSON gsMappings.previousHunk.value} end
 
               vim.schedule(function() package.loaded.gitsigns.prev_hunk() end)
 

--- a/modules/git/git.nix
+++ b/modules/git/git.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkMappingOption;
+in {
   options.vim.git = {
     enable = mkEnableOption "git tools via gitsigns";
 

--- a/modules/minimap/codewindow/codewindow.nix
+++ b/modules/minimap/codewindow/codewindow.nix
@@ -1,5 +1,6 @@
-{lib, ...}:
-with lib; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkMappingOption;
+in {
   options.vim.minimap.codewindow = {
     enable = mkEnableOption "codewindow plugin for minimap view";
 

--- a/modules/minimap/codewindow/config.nix
+++ b/modules/minimap/codewindow/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkIf mkMerge mkSetLuaBinding nvim;
+
   cfg = config.vim.minimap.codewindow;
 
   self = import ./codewindow.nix {inherit lib;};

--- a/modules/minimap/minimap-vim/config.nix
+++ b/modules/minimap/minimap-vim/config.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf;
+
   cfg = config.vim.minimap.minimap-vim;
 in {
   config = mkIf cfg.enable {

--- a/modules/minimap/minimap-vim/minimap-vim.nix
+++ b/modules/minimap/minimap-vim/minimap-vim.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.minimap.minimap-vim = {
     enable = mkEnableOption "minimap-vim plugin for minimap view";
   };

--- a/modules/notes/mind-nvim/config.nix
+++ b/modules/notes/mind-nvim/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.notes.mind-nvim;
 in {
   config = mkIf (cfg.enable) {

--- a/modules/notes/mind-nvim/mind-nvim.nix
+++ b/modules/notes/mind-nvim/mind-nvim.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.notes.mind-nvim = {
     enable = mkEnableOption "organizer tool for Neovim.";
   };

--- a/modules/notes/obsidian/config.nix
+++ b/modules/notes/obsidian/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.notes.obsidian;
   auto = config.vim.autocomplete;
 in {

--- a/modules/notes/obsidian/obsidian.nix
+++ b/modules/notes/obsidian/obsidian.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.notes = {
     obsidian = {
       enable = mkEnableOption "complementary neovim plugins for Obsidian editor";

--- a/modules/notes/orgmode/config.nix
+++ b/modules/notes/orgmode/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf mkMerge nvim;
+
   cfg = config.vim.notes.orgmode;
 in {
   config = mkIf cfg.enable (mkMerge [

--- a/modules/notes/orgmode/orgmode.nix
+++ b/modules/notes/orgmode/orgmode.nix
@@ -3,9 +3,9 @@
   lib,
   pkgs,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption types mkOption nvim;
+in {
   options.vim.notes.orgmode = {
     enable = mkEnableOption "nvim-orgmode: Neovim plugin for Emac Orgmode. Get the best of both worlds";
 

--- a/modules/notes/todo-comments/config.nix
+++ b/modules/notes/todo-comments/config.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkMerge mkBinding mkIf;
+
   cfg = config.vim.notes.todo-comments;
   self = import ./todo-comments.nix {inherit lib;};
   mappings = self.options.vim.notes.todo-comments.mappings;

--- a/modules/notes/todo-comments/todo-comments.nix
+++ b/modules/notes/todo-comments/todo-comments.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types mkMappingOption;
+in {
   options.vim.notes.todo-comments = {
     enable = mkEnableOption "todo-comments: highlight and search for todo comments like TODO, HACK, BUG in your code base";
 

--- a/modules/projects/project-nvim/config.nix
+++ b/modules/projects/project-nvim/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim boolToString concatStringsSep;
+
   cfg = config.vim.projects.project-nvim;
 in {
   config = mkIf cfg.enable {

--- a/modules/projects/project-nvim/project-nvim.nix
+++ b/modules/projects/project-nvim/project-nvim.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.projects.project-nvim = {
     enable = mkEnableOption "project-nvim for project management";
 

--- a/modules/rich-presence/presence-nvim/config.nix
+++ b/modules/rich-presence/presence-nvim/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim boolToString;
+
   cfg = config.vim.presence.presence-nvim;
 in {
   config = mkIf cfg.enable {

--- a/modules/rich-presence/presence-nvim/presence-nvim.nix
+++ b/modules/rich-presence/presence-nvim/presence-nvim.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.presence.presence-nvim = {
     enable = mkEnableOption "presence.nvim plugin for discord rich presence";
 

--- a/modules/session/nvim-session-manager/config.nix
+++ b/modules/session/nvim-session-manager/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf optionals mkMerge mkBinding nvim concatStringsSep boolToString;
+
   cfg = config.vim.session.nvim-session-manager;
 in {
   config = mkIf cfg.enable {

--- a/modules/session/nvim-session-manager/nvim-session-manager.nix
+++ b/modules/session/nvim-session-manager/nvim-session-manager.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.session.nvim-session-manager = {
     enable = mkEnableOption "nvim-session-manager: manage sessions like folders in VSCode";
 

--- a/modules/snippets/vsnip/config.nix
+++ b/modules/snippets/vsnip/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf;
+
   cfg = config.vim.snippets.vsnip;
 in {
   config = mkIf cfg.enable {

--- a/modules/snippets/vsnip/vsnip.nix
+++ b/modules/snippets/vsnip/vsnip.nix
@@ -1,5 +1,6 @@
-{lib, ...}:
-with lib; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.snippets.vsnip = {
     enable = mkEnableOption "vim-vsnip: snippet LSP/VSCode's format";
   };

--- a/modules/statusline/lualine/config.nix
+++ b/modules/statusline/lualine/config.nix
@@ -2,10 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib; let
+}: let
   cfg = config.vim.statusline.lualine;
-  inherit (nvim.lua) luaTable;
+  inherit (lib) mkIf nvim boolToString optionalString;
 in {
   config = (mkIf cfg.enable) {
     vim.startPlugins = [
@@ -33,21 +32,21 @@ in {
         },
         -- active sections
         sections = {
-          lualine_a = ${luaTable (cfg.activeSection.a ++ cfg.extraActiveSection.a)},
-          lualine_b = ${luaTable (cfg.activeSection.b ++ cfg.extraActiveSection.b)},
-          lualine_c = ${luaTable (cfg.activeSection.c ++ cfg.extraActiveSection.c)},
-          lualine_x = ${luaTable (cfg.activeSection.x ++ cfg.extraActiveSection.x)},
-          lualine_y = ${luaTable (cfg.activeSection.y ++ cfg.extraActiveSection.y)},
-          lualine_z = ${luaTable (cfg.activeSection.z ++ cfg.extraActiveSection.z)},
+          lualine_a = ${nvim.lua.luaTable (cfg.activeSection.a ++ cfg.extraActiveSection.a)},
+          lualine_b = ${nvim.lua.luaTable (cfg.activeSection.b ++ cfg.extraActiveSection.b)},
+          lualine_c = ${nvim.lua.luaTable (cfg.activeSection.c ++ cfg.extraActiveSection.c)},
+          lualine_x = ${nvim.lua.luaTable (cfg.activeSection.x ++ cfg.extraActiveSection.x)},
+          lualine_y = ${nvim.lua.luaTable (cfg.activeSection.y ++ cfg.extraActiveSection.y)},
+          lualine_z = ${nvim.lua.luaTable (cfg.activeSection.z ++ cfg.extraActiveSection.z)},
         },
         --
         inactive_sections = {
-          lualine_a = ${luaTable (cfg.inactiveSection.a ++ cfg.extraInactiveSection.a)},
-          lualine_b = ${luaTable (cfg.inactiveSection.b ++ cfg.extraInactiveSection.b)},
-          lualine_c = ${luaTable (cfg.inactiveSection.c ++ cfg.extraInactiveSection.c)},
-          lualine_x = ${luaTable (cfg.inactiveSection.x ++ cfg.extraInactiveSection.x)},
-          lualine_y = ${luaTable (cfg.inactiveSection.y ++ cfg.extraInactiveSection.y)},
-          lualine_z = ${luaTable (cfg.inactiveSection.z ++ cfg.extraInactiveSection.z)},
+          lualine_a = ${nvim.lua.luaTable (cfg.inactiveSection.a ++ cfg.extraInactiveSection.a)},
+          lualine_b = ${nvim.lua.luaTable (cfg.inactiveSection.b ++ cfg.extraInactiveSection.b)},
+          lualine_c = ${nvim.lua.luaTable (cfg.inactiveSection.c ++ cfg.extraInactiveSection.c)},
+          lualine_x = ${nvim.lua.luaTable (cfg.inactiveSection.x ++ cfg.extraInactiveSection.x)},
+          lualine_y = ${nvim.lua.luaTable (cfg.inactiveSection.y ++ cfg.extraInactiveSection.y)},
+          lualine_z = ${nvim.lua.luaTable (cfg.inactiveSection.z ++ cfg.extraInactiveSection.z)},
         },
         tabline = {},
 

--- a/modules/statusline/lualine/lualine.nix
+++ b/modules/statusline/lualine/lualine.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkEnableOption mkOption types elem optional;
+
   supported_themes = import ./supported_themes.nix;
   colorPuccin =
     if config.vim.statusline.lualine.theme == "catppuccin"

--- a/modules/tabline/nvim-bufferline/config.nix
+++ b/modules/tabline/nvim-bufferline/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf mkMerge mkLuaBinding mkBinding nvim;
+
   cfg = config.vim.tabline.nvimBufferline;
   self = import ./nvim-bufferline.nix {
     inherit lib;

--- a/modules/tabline/nvim-bufferline/nvim-bufferline.nix
+++ b/modules/tabline/nvim-bufferline/nvim-bufferline.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkMappingOption;
+in {
   options.vim.tabline.nvimBufferline = {
     enable = mkEnableOption "nvim-bufferline-lua as a bufferline";
 

--- a/modules/terminal/toggleterm/config.nix
+++ b/modules/terminal/toggleterm/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkMerge mkIf mkBinding nvim getExe;
+
   cfg = config.vim.terminal.toggleterm;
 in {
   config = mkMerge [
@@ -59,7 +59,7 @@ in {
             end
           })
 
-          vim.keymap.set('n', ${toJSON cfg.lazygit.mappings.open}, function() lazygit:toggle() end, {silent = true, noremap = true, desc = 'Open lazygit [toggleterm]'})
+          vim.keymap.set('n', ${builtins.toJSON cfg.lazygit.mappings.open}, function() lazygit:toggle() end, {silent = true, noremap = true, desc = 'Open lazygit [toggleterm]'})
         '';
       }
     )

--- a/modules/terminal/toggleterm/toggleterm.nix
+++ b/modules/terminal/toggleterm/toggleterm.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types mkMappingOption;
+in {
   options.vim.terminal.toggleterm = {
     enable = mkEnableOption "toggleterm as a replacement to built-in terminal command";
     mappings = {

--- a/modules/theme/config.nix
+++ b/modules/theme/config.nix
@@ -2,8 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib; {
+}: let
+  inherit (lib) mkDefault;
+in {
   config = {
     vim.theme = {
       enable = mkDefault false;

--- a/modules/theme/theme.nix
+++ b/modules/theme/theme.nix
@@ -2,10 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with lib.attrsets;
-with builtins; let
+}: let
+  inherit (lib) mkOption types attrNames mkIf nvim;
+
   cfg = config.vim.theme;
   supported_themes = import ./supported_themes.nix {inherit lib;};
 in {

--- a/modules/treesitter/config.nix
+++ b/modules/treesitter/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkIf optional mkSetBinding mkMerge nvim;
+
   cfg = config.vim.treesitter;
   usingNvimCmp = config.vim.autocomplete.enable && config.vim.autocomplete.type == "nvim-cmp";
 

--- a/modules/treesitter/context.nix
+++ b/modules/treesitter/context.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkEnableOption mkOption types mkIf nvim boolToString;
+
   treesitter = config.vim.treesitter;
   cfg = treesitter.context;
 in {

--- a/modules/treesitter/treesitter.nix
+++ b/modules/treesitter/treesitter.nix
@@ -1,5 +1,6 @@
-{lib, ...}:
-with lib; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkMappingOption mkOption types;
+in {
   options.vim.treesitter = {
     enable = mkEnableOption "treesitter, also enabled automatically through language options";
 

--- a/modules/ui/colorizer/colorizer.nix
+++ b/modules/ui/colorizer/colorizer.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.ui.colorizer = {
     enable = mkEnableOption "nvim-colorizer.lua for color highlighting";
 

--- a/modules/ui/colorizer/config.nix
+++ b/modules/ui/colorizer/config.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim boolToString;
+
   cfg = config.vim.ui.colorizer;
 in {
   config = mkIf cfg.enable {

--- a/modules/ui/illuminate/config.nix
+++ b/modules/ui/illuminate/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.ui.illuminate;
 in {
   config = mkIf cfg.enable {

--- a/modules/ui/illuminate/illuminate.nix
+++ b/modules/ui/illuminate/illuminate.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.ui.illuminate = {
     enable = mkEnableOption "vim-illuminate: automatically highlight other uses of the word under the cursor";
   };

--- a/modules/ui/modes/config.nix
+++ b/modules/ui/modes/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim boolToString;
+
   cfg = config.vim.ui.modes-nvim;
 in {
   config = mkIf cfg.enable {

--- a/modules/ui/modes/modes.nix
+++ b/modules/ui/modes/modes.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.ui.modes-nvim = {
     enable = mkEnableOption "modes.nvim's prismatic line decorations";
 

--- a/modules/ui/noice/config.nix
+++ b/modules/ui/noice/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim boolToString;
+
   cfg = config.vim.ui.noice;
 in {
   config = mkIf cfg.enable {

--- a/modules/ui/noice/noice.nix
+++ b/modules/ui/noice/noice.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.ui.noice = {
     enable = mkEnableOption "noice-nvim UI modification library";
   };

--- a/modules/ui/notifications/nvim-notify/config.nix
+++ b/modules/ui/notifications/nvim-notify/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.notify.nvim-notify;
 in {
   config = mkIf cfg.enable {

--- a/modules/ui/notifications/nvim-notify/nvim-notify.nix
+++ b/modules/ui/notifications/nvim-notify/nvim-notify.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.notify.nvim-notify = {
     enable = mkEnableOption "nvim-notify notifications";
     stages = mkOption {

--- a/modules/ui/smartcolumn/config.nix
+++ b/modules/ui/smartcolumn/config.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim concatStringsSep;
+
   cfg = config.vim.ui.smartcolumn;
 in {
   config = mkIf cfg.enable {

--- a/modules/ui/smartcolumn/smartcolumn.nix
+++ b/modules/ui/smartcolumn/smartcolumn.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.ui.smartcolumn = {
     enable = mkEnableOption "line length indicator";
 

--- a/modules/utility/binds/cheatsheet/cheatsheet.nix
+++ b/modules/utility/binds/cheatsheet/cheatsheet.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.binds.cheatsheet = {
     enable = mkEnableOption "cheatsheet-nvim: searchable cheatsheet for nvim using telescope";
   };

--- a/modules/utility/binds/cheatsheet/config.nix
+++ b/modules/utility/binds/cheatsheet/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.binds.cheatsheet;
 in {
   config = mkIf (cfg.enable) {

--- a/modules/utility/binds/which-key/config.nix
+++ b/modules/utility/binds/which-key/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.binds.whichKey;
 in {
   config = mkIf (cfg.enable) {

--- a/modules/utility/binds/which-key/which-key.nix
+++ b/modules/utility/binds/which-key/which-key.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.binds.whichKey = {
     enable = mkEnableOption "which-key keybind helper menu";
   };

--- a/modules/utility/ccc/ccc.nix
+++ b/modules/utility/ccc/ccc.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkMappingOption;
+in {
   options.vim.utility.ccc = {
     enable = mkEnableOption "ccc color picker for neovim";
 

--- a/modules/utility/ccc/config.nix
+++ b/modules/utility/ccc/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkIf nvim;
+
   cfg = config.vim.utility.ccc;
   self = import ./ccc.nix {inherit lib;};
 

--- a/modules/utility/diffview/config.nix
+++ b/modules/utility/diffview/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.utility.diffview-nvim;
 in {
   config = mkIf (cfg.enable) {

--- a/modules/utility/diffview/diffview.nix
+++ b/modules/utility/diffview/diffview.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.utility.diffview-nvim = {
     enable = mkEnableOption "diffview-nvim: cycle through diffs for all modified files for any git rev";
   };

--- a/modules/utility/gestures/gesture-nvim/config.nix
+++ b/modules/utility/gestures/gesture-nvim/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkIf mkMerge mkSetLuaBinding nvim;
+
   cfg = config.vim.gestures.gesture-nvim;
 
   self = import ./gesture-nvim.nix {inherit lib;};

--- a/modules/utility/gestures/gesture-nvim/gesture-nvim.nix
+++ b/modules/utility/gestures/gesture-nvim/gesture-nvim.nix
@@ -1,5 +1,6 @@
-{lib, ...}:
-with lib; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkMappingOption;
+in {
   options.vim.gestures.gesture-nvim = {
     enable = mkEnableOption "gesture-nvim: mouse gestures";
 

--- a/modules/utility/icon-picker/config.nix
+++ b/modules/utility/icon-picker/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.utility.icon-picker;
 in {
   config = mkIf (cfg.enable) {

--- a/modules/utility/icon-picker/icon-picker.nix
+++ b/modules/utility/icon-picker/icon-picker.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption;
+in {
   options.vim.utility.icon-picker = {
     enable = mkEnableOption "nerdfonts icon picker for nvim";
   };

--- a/modules/utility/motion/hop/config.nix
+++ b/modules/utility/motion/hop/config.nix
@@ -2,8 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkIf mkSetBinding nvim;
+
   cfg = config.vim.utility.motion.hop;
 
   self = import ./hop.nix {inherit lib;};

--- a/modules/utility/motion/hop/hop.nix
+++ b/modules/utility/motion/hop/hop.nix
@@ -1,5 +1,6 @@
-{lib, ...}:
-with lib; {
+{lib, ...}: let
+  inherit (lib) mkMappingOption mkEnableOption;
+in {
   options.vim.utility.motion.hop = {
     mappings = {
       hop = mkMappingOption "Jump to occurences [hop.nvim]" "<leader>h";

--- a/modules/utility/motion/leap/config.nix
+++ b/modules/utility/motion/leap/config.nix
@@ -2,8 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib; let
+}: let
+  inherit (lib) mkIf mkMerge mkBinding nvim;
+
   cfg = config.vim.utility.motion.leap;
 in {
   config = mkIf cfg.enable {

--- a/modules/utility/motion/leap/leap.nix
+++ b/modules/utility/motion/leap/leap.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.utility.motion.leap = {
     enable = mkEnableOption "leap.nvim plugin (easy motion)";
 

--- a/modules/utility/surround/config.nix
+++ b/modules/utility/surround/config.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkIf mkMerge mkSetBinding nvim;
+
   cfg = config.vim.utility.surround;
   self = import ./surround.nix {inherit lib config;};
   mappingDefinitions = self.options.vim.utility.surround.mappings;

--- a/modules/utility/surround/surround.nix
+++ b/modules/utility/surround/surround.nix
@@ -2,9 +2,9 @@
   lib,
   config,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkOption types mkIf mkDefault;
+in {
   options.vim.utility.surround = {
     enable = mkOption {
       type = types.bool;

--- a/modules/utility/telescope/config.nix
+++ b/modules/utility/telescope/config.nix
@@ -3,9 +3,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) addDescriptionsToMappings mkIf mkMerge mkSetBinding nvim;
+
   cfg = config.vim.telescope;
   self = import ./telescope.nix {inherit lib;};
   mappingDefinitions = self.options.vim.telescope.mappings;

--- a/modules/utility/telescope/telescope.nix
+++ b/modules/utility/telescope/telescope.nix
@@ -1,6 +1,6 @@
-{lib, ...}:
-with lib;
-with builtins; {
+{lib, ...}: let
+  inherit (lib) mkMappingOption mkEnableOption;
+in {
   options.vim.telescope = {
     mappings = {
       findProjects = mkMappingOption "Find files [Telescope]" "<leader>fp";

--- a/modules/utility/wakatime/config.nix
+++ b/modules/utility/wakatime/config.nix
@@ -3,9 +3,9 @@
   lib,
   pkgs,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkIf nvim;
+
   cfg = config.vim.utility.vim-wakatime;
 in {
   config = mkIf (cfg.enable) {

--- a/modules/utility/wakatime/vim-wakatime.nix
+++ b/modules/utility/wakatime/vim-wakatime.nix
@@ -2,9 +2,9 @@
   lib,
   pkgs,
   ...
-}:
-with lib;
-with builtins; {
+}: let
+  inherit (lib) mkEnableOption mkOption types;
+in {
   options.vim.utility.vim-wakatime = {
     enable = mkEnableOption "vim-wakatime: live code statistics";
 

--- a/modules/visuals/config.nix
+++ b/modules/visuals/config.nix
@@ -2,8 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib; let
+}: let
+  inherit (lib) mkIf mkMerge nvim optionalString boolToString mkBinding;
+
   cfg = config.vim.visuals;
 in {
   config = mkIf cfg.enable (mkMerge [

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -2,9 +2,9 @@
   config,
   lib,
   ...
-}:
-with lib;
-with builtins; let
+}: let
+  inherit (lib) mkEnableOption mkMappingOption mkOption types literalExpression;
+
   cfg = config.vim.visuals;
 in {
   options.vim.visuals = {


### PR DESCRIPTION
Changes most modules, only ones remaining are `lsp` and `languages` (I hope). The opportunity is yours @NotAShelf.