### PR TITLE
lib: function for custom plugin `setup()` arguments

### DIFF
--- a/lib/types/default.nix
+++ b/lib/types/default.nix
@@ -4,6 +4,6 @@
   typesLanguage = import ./languages.nix {inherit lib;};
 in {
   inherit (typesDag) dagOf;
-  inherit (typesPlugin) pluginsOpt extraPluginType;
+  inherit (typesPlugin) pluginsOpt extraPluginType mkPluginSetupOption;
   inherit (typesLanguage) diagnostics mkGrammarOption;
 }

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -138,4 +138,25 @@ in {
       inherit description default;
       type = pluginsType;
     };
+
+  # opts is a attrset of options, example:
+  # ```
+  # mkPluginSetupOption "telescope" {
+  #   file_ignore_patterns = mkOption {
+  #     description = "...";
+  #     type = types.listOf types.str;
+  #     default = [];
+  #   };
+  #   layout_config.horizontal = mkOption {...};
+  # }
+  # ```
+  mkPluginSetupOption = pluginName: opts:
+    mkOption {
+      description = "Option table to pass into the setup function of " + pluginName;
+      default = {};
+      type = types.submodule {
+        freeformType = with types; attrsOf anything;
+        options = opts;
+      };
+    };
 }


### PR DESCRIPTION
closes #133 

I started playing around with the idea a bit more. will try to convert the bigger plugins first to get a grasp on how it would go

progress (by directories in `modules/`)

  - [ ] assistant
  - [ ] autopairs
  - [ ] basic
  - [ ] comments
  - [ ] completion
  - [ ] core
  - [ ] dashboard
  - [ ] debugger
  - [x] filetree
  - [ ] git
  - [ ] languages
  - [ ] lsp
  - [ ] minimap
  - [ ] notes
  - [ ] projects
  - [ ] rich-presence
  - [ ] session
  - [ ] snippets
  - [x] statusline
  - [ ] tabline
  - [ ] terminal
  - [ ] theme
  - [ ] treesitter
  - [ ] ui
  - [ ] utility
    - [x] telescope
  - [ ] visuals

random bugs I found:

1. telescope: all the options should be under `defaults` but most are not
2. lualine: `extensions` should not be under `options`