### PR TITLE
modules/rich-presence: deprecate presence-nvim in favor of neocord

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -232,17 +232,7 @@ inputs: let
       };
 
       vim.presence = {
-        presence-nvim = {
-          enable = true;
-          auto_update = true;
-          image_text = "The Superior Text Editor";
-          client_id = "793271441293967371";
-          main_image = "neovim";
-          show_time = true;
-          rich_presence = {
-            editing_text = "Editing %s";
-          };
-        };
+        neocord.enable = true;
       };
     };
   };

--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -17,3 +17,7 @@ Release notes for release 0.6
 - Finished moving to `nixosOptionsDoc` in the documentation and changelog. We are fully free of asciidoc now
 
 - Bumped plugin inputs to their latest versions
+
+- Deprecated `presence.nvim` in favor of `neocord`. This means `vim.rich-presence.presence-nvim` is removed and will throw
+  a warning if used. You are recommended to rewrite your neocord config from scratch based on the
+  [official documentation](https://github.com/IogaMaster/neocord)

--- a/flake.lock
+++ b/flake.lock
@@ -778,6 +778,22 @@
         "type": "github"
       }
     },
+    "neocord": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1704948184,
+        "narHash": "sha256-HnaMKTNjMuDwHDvxHH5kd4ysa5WU+MlbdD9jH/iJcU8=",
+        "owner": "IogaMaster",
+        "repo": "neocord",
+        "rev": "9b624d5189f699ab454e9515262c13965395b8dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IogaMaster",
+        "repo": "neocord",
+        "type": "github"
+      }
+    },
     "neodev-nvim": {
       "flake": false,
       "locked": {
@@ -1397,22 +1413,6 @@
         "type": "github"
       }
     },
-    "presence-nvim": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1674984077,
-        "narHash": "sha256-ZpsunLsn//zYgUtmAm5FqKVueVd/Pa1r55ZDqxCimBk=",
-        "owner": "andweeb",
-        "repo": "presence.nvim",
-        "rev": "87c857a56b7703f976d3a5ef15967d80508df6e6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "andweeb",
-        "repo": "presence.nvim",
-        "type": "github"
-      }
-    },
     "project-nvim": {
       "flake": false,
       "locked": {
@@ -1511,6 +1511,7 @@
         "mind-nvim": "mind-nvim",
         "minimap-vim": "minimap-vim",
         "modes-nvim": "modes-nvim",
+        "neocord": "neocord",
         "neodev-nvim": "neodev-nvim",
         "nil": "nil",
         "nixpkgs": "nixpkgs",
@@ -1545,7 +1546,6 @@
         "orgmode-nvim": "orgmode-nvim",
         "oxocarbon": "oxocarbon",
         "plenary-nvim": "plenary-nvim",
-        "presence-nvim": "presence-nvim",
         "project-nvim": "project-nvim",
         "registers": "registers",
         "rnix-lsp": "rnix-lsp",

--- a/flake.lock
+++ b/flake.lock
@@ -836,11 +836,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703013332,
-        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
+        "lastModified": 1704194953,
+        "narHash": "sha256-RtDKd8Mynhe5CFnVT8s0/0yqtWFMM9LmCzXv/YKxnq4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
+        "rev": "bd645e8668ec6612439a9ee7e71f7eac4099d4f6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -262,9 +262,9 @@
     };
 
     # Presence
-    presence-nvim = {
-      url = "github:andweeb/presence.nvim";
-      flake = false;
+    neocord = {
+      url = "github:IogaMaster/neocord";
+      flake = false; # uses flake-utils, avoid the flake
     };
 
     # Autopairs

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -53,7 +53,7 @@ with lib; let
     "cheatsheet-nvim"
     "ccc"
     "cellular-automaton"
-    "presence-nvim"
+    "neocord"
     "icon-picker-nvim"
     "dressing-nvim"
     "orgmode-nvim"

--- a/modules/rich-presence/default.nix
+++ b/modules/rich-presence/default.nix
@@ -1,5 +1,5 @@
-_: {
+{
   imports = [
-    ./presence-nvim
+    ./neocord
   ];
 }

--- a/modules/rich-presence/neocord/config.nix
+++ b/modules/rich-presence/neocord/config.nix
@@ -4,26 +4,29 @@
   ...
 }: let
   inherit (lib) mkIf nvim boolToString;
+  inherit (lib.nvim.lua) listToLuaTable;
+  inherit (builtins) toString;
 
-  cfg = config.vim.presence.presence-nvim;
+  cfg = config.vim.presence.neocord;
 in {
   config = mkIf cfg.enable {
-    vim.startPlugins = ["presence-nvim"];
+    vim.startPlugins = ["neocord"];
 
-    vim.luaConfigRC.presence-nvim = nvim.dag.entryAnywhere ''
-      -- Description of each option can be found in https://github.com/andweeb/presence.nvim
-      require("presence").setup({
+    vim.luaConfigRC.neocord = nvim.dag.entryAnywhere ''
+      -- Description of each option can be found in https://github.com/IogaMaster/neocord#lua
+      require("neocord").setup({
           -- General options
-          auto_update         = true,
-          neovim_image_text   = "${cfg.image_text}",
+          logo                = "${cfg.logo}",
+          logo_tooltip        = "${cfg.logo_tooltip}",
           main_image          = "${cfg.main_image}",
           client_id           = "${cfg.client_id}",
-          log_level           = nil,
-          debounce_timeout    = 10,
-          enable_line_number  = "${boolToString cfg.enable_line_number}",
-          blacklist           = {},
-          buttons             = "${boolToString cfg.buttons}",
-          file_assets         = {},
+          log_level           = "${
+        if cfg.log_level == null
+        then "nil"
+        else cfg.log_level
+      }",
+          debounce_timeout    = ${toString cfg.debounce_timeout},
+          blacklist           = ${listToLuaTable cfg.blacklist},
           show_time           = "${boolToString cfg.show_time}",
 
           -- Rich Presence text options
@@ -34,6 +37,7 @@ in {
           reading_text        = "${cfg.rich_presence.reading_text}",
           workspace_text      = "${cfg.rich_presence.workspace_text}",
           line_number_text    = "${cfg.rich_presence.line_number_text}",
+          terminal_text       = "${cfg.rich_presence.terminal_text}",
       })
     '';
   };

--- a/modules/rich-presence/neocord/default.nix
+++ b/modules/rich-presence/neocord/default.nix
@@ -1,6 +1,6 @@
-_: {
+{
   imports = [
     ./config.nix
-    ./presence-nvim.nix
+    ./neocord.nix
   ];
 }

--- a/modules/rich-presence/neocord/neocord.nix
+++ b/modules/rich-presence/neocord/neocord.nix
@@ -1,29 +1,56 @@
-{
-  config,
-  lib,
-  ...
-}: let
-  inherit (lib) mkEnableOption mkOption types;
+{lib, ...}: let
+  inherit (lib) mkEnableOption mkOption types literalExpression mkRemovedOptionModule;
 in {
-  options.vim.presence.presence-nvim = {
-    enable = mkEnableOption "presence.nvim plugin for discord rich presence";
+  imports = [
+    (mkRemovedOptionModule ["vim" "presence" "presence-nvim"] ''
+      The option vim.presence.presence-nvim has been deprecated in favor of the new neocord module.
+      Options provided by the plugin remain mostly the same, but manual migration is required.
 
-    image_text = mkOption {
+      Please see neocord documentation and the neovim-flake options for more info
+    '')
+  ];
+
+  options.vim.presence.neocord = {
+    enable = mkEnableOption "neocord plugin for discord rich presence";
+
+    logo = mkOption {
+      type = types.str; # TODO: can the default be documented better, maybe with an enum?
+      default = "auto";
+      description = ''
+        Logo to be displayed on the RPC item
+
+        This must be either "auto" or an URL to your image of choice
+      '';
+    };
+
+    logo_tooltip = mkOption {
       type = types.str;
       default = "The One True Text Editor";
       description = "Text displayed when hovering over the Neovim image";
     };
 
     main_image = mkOption {
-      type = types.str;
-      default = "neovim";
+      type = types.enum ["language" "logo"];
+      default = "language";
       description = "Main image to be displayed";
     };
 
     client_id = mkOption {
       type = types.str;
-      default = "79327144129396737";
+      default = "1157438221865717891";
       description = "Client ID of the application";
+    };
+
+    log_level = mkOption {
+      type = with types; nullOr (enum ["debug" "info" "warn" "error"]);
+      default = null;
+      description = "Log level to be used by the plugin";
+    };
+
+    debounce_timeout = mkOption {
+      type = types.int;
+      default = 10;
+      description = "Number of seconds to debounce events";
     };
 
     auto_update = mkOption {
@@ -38,16 +65,17 @@ in {
       description = "Show line number on the RPC item";
     };
 
-    buttons = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Show buttons on the RPC item";
-    };
-
     show_time = mkOption {
       type = types.bool;
       default = true;
       description = "Show time on the RPC item";
+    };
+
+    blacklist = mkOption {
+      type = with types; listOf str;
+      default = [];
+      example = literalExpression ''["Alpha"]'';
+      description = "List of filetypes to ignore";
     };
 
     rich_presence = {
@@ -91,6 +119,12 @@ in {
         type = types.str;
         default = "Line %s out of %s";
         description = "Text displayed when showing line number";
+      };
+
+      terminal_text = mkOption {
+        type = types.str;
+        default = "Working on the terminal";
+        description = "Text displayed when working on the terminal";
       };
     };
   };


### PR DESCRIPTION
Presence.nvim hasn't been updated in around 2 years and in my testing, I've noticed that it does not work with the latest versions of arRPC. Replaced it with the more up-to-date neocord.

Minor changes to the module definitions. Mostly the same, but some options (such as buttons) are removed entirely.