### PR TITLE
Language/markdown: Added LSP and fixed Glow not working

### DIFF
--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -27,3 +27,5 @@ Release notes for release 0.6
 - Added Gruvbox theme
 
 - Added marksman LSP for Markdown
+
+- Fixed Markdown-previewer Glow not working and added an option for changing the preview keybind

--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -25,3 +25,5 @@ Release notes for release 0.6
 [donnerinoern](https://github.com/donnerinoern):
 
 - Added Gruvbox theme
+
+- Added marksman LSP for Markdown

--- a/modules/languages/markdown/config.nix
+++ b/modules/languages/markdown/config.nix
@@ -4,9 +4,25 @@
   lib,
   ...
 }: let
-  inherit (lib) nvim mkIf mkMerge;
+  inherit (lib) nvim mkIf mkMerge isList;
 
   cfg = config.vim.languages.markdown;
+  servers = {
+    marksman = {
+      package = pkgs.marksman;
+      lspConfig = ''
+        lspconfig.marksman.setup{
+          capabilities = capabilities;
+          on_attach = default_on_attach;
+          cmd = ${
+          if isList cfg.lsp.package
+          then nvim.lua.expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/marksman", "server"}''
+        },
+        }
+      '';
+    };
+  };
 in {
   config = mkIf cfg.enable (mkMerge [
     (mkIf cfg.treesitter.enable {
@@ -25,6 +41,12 @@ in {
       vim.configRC.glow = nvim.dag.entryAnywhere ''
         autocmd FileType markdown noremap <leader>p :Glow<CR>
       '';
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+
+      vim.lsp.lspconfig.sources.markdown-lsp = servers.${cfg.lsp.server}.lspConfig;
     })
   ]);
 }

--- a/modules/languages/markdown/markdown.nix
+++ b/modules/languages/markdown/markdown.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   inherit (builtins) attrNames;
-  inherit (lib) mkEnableOption mkOption types nvim isList;
+  inherit (lib) mkEnableOption mkMappingOption mkOption types nvim isList;
 
   cfg = config.vim.languages.markdown;
   defaultServer = "marksman";
@@ -29,10 +29,15 @@ in {
   options.vim.languages.markdown = {
     enable = mkEnableOption "Markdown markup language support";
 
-    glow.enable = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable markdown preview in neovim with glow";
+    glow = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable markdown preview in neovim with glow";
+      };
+      mappings = {
+        openPreview = mkMappingOption "Open preview" "<leader>p";
+      };
     };
 
     treesitter = {

--- a/modules/languages/markdown/markdown.nix
+++ b/modules/languages/markdown/markdown.nix
@@ -4,9 +4,27 @@
   lib,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption types nvim;
+  inherit (builtins) attrNames;
+  inherit (lib) mkEnableOption mkOption types nvim isList;
 
   cfg = config.vim.languages.markdown;
+  defaultServer = "marksman";
+  servers = {
+    marksman = {
+      package = pkgs.marksman;
+      lspConfig = ''
+        lspconfig.marksman.setup{
+          capabilities = capabilities;
+          on_attach = default_on_attach;
+          cmd = ${
+          if isList cfg.lsp.package
+          then nvim.lua.expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/marksman", "server"}''
+        },
+        }
+      '';
+    };
+  };
 in {
   options.vim.languages.markdown = {
     enable = mkEnableOption "Markdown markup language support";
@@ -25,6 +43,23 @@ in {
       };
       mdPackage = nvim.types.mkGrammarOption pkgs "markdown";
       mdInlinePackage = nvim.types.mkGrammarOption pkgs "markdown-inline";
+    };
+
+    lsp = {
+      enable = mkEnableOption "Enable Markdown LSP support" // {default = config.vim.languages.enableLSP;};
+
+      server = mkOption {
+        description = "Markdown LSP server to use";
+        type = with types; enum (attrNames servers);
+        default = defaultServer;
+      };
+
+      package = mkOption {
+        description = "Markdown LSP server package, or the command to run as a list of strings";
+        example = ''[lib.getExe pkgs.jdt-language-server " - data " " ~/.cache/jdtls/workspace "]'';
+        type = with types; either package (listOf str);
+        default = servers.${cfg.lsp.server}.package;
+      };
     };
   };
 }


### PR DESCRIPTION
# Description

I don't know if it's good practice to combine two commits into one PR like this, but they both touch on the same module, so I figured it would probably be okay. Correct me if I'm wrong.

The first commit adds marksman as a markdown LSP. It also provides the same options that the other language modules do.

The second commit fixes Glow, which I noticed wasn't working correctly (or at all). As with the first commit, new option(s) are provided. There is now an option for changing the preview keybind, which by default is the same bind that it was before (\<Leader>p).

## Type of change

- Bug fix (I guess. Glow not working hasn't been reported as an issue, though)
- New feature

## Checklist

- [x] My code follows the style and contributing guidelines of this project.
- [x] I ran Alejandra to format my code (`nix fmt`).
- [x] I have performed a self-review of my own code and tested it.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] This change requires a documentation update.
- [ ] I have updated the documentation accordingly.

## Screenshots & Logs

The maximal config completely fails to build for me, so I replaced it with my own. When using my own, I get no new errors, nor any new warnings.
![image](https://github.com/NotAShelf/neovim-flake/assets/72634505/d7b2b24d-e771-4c49-8d38-477c3537c1f3)
![image](https://github.com/NotAShelf/neovim-flake/assets/72634505/c48bd4d0-716e-40fe-badf-7f1e55583288)
![image](https://github.com/NotAShelf/neovim-flake/assets/72634505/e99d3ff6-c91e-4d77-8014-3e5b1a5c7858)
