### PR TITLE
languages: add css and tailwind language support

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -56,15 +56,8 @@ inputs: let
 
         nix.enable = true;
         html.enable = isMaximal;
-        clang = {
-          enable = isMaximal;
-          lsp.server = "clangd";
-        };
+        css.enable = isMaximal;
         sql.enable = isMaximal;
-        rust = {
-          enable = isMaximal;
-          crates.enable = true;
-        };
         java.enable = isMaximal;
         ts.enable = isMaximal;
         svelte.enable = isMaximal;
@@ -72,9 +65,19 @@ inputs: let
         zig.enable = isMaximal;
         python.enable = isMaximal;
         dart.enable = isMaximal;
-        elixir.enable = false;
+        elixir.enable = isMaximal;
         bash.enable = isMaximal;
         terraform.enable = isMaximal;
+        tailwind.enable = isMaximal;
+        clang = {
+          enable = isMaximal;
+          lsp.server = "clangd";
+        };
+
+        rust = {
+          enable = isMaximal;
+          crates.enable = true;
+        };
       };
 
       vim.visuals = {

--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -22,6 +22,9 @@ Release notes for release 0.6
   a warning if used. You are recommended to rewrite your neocord config from scratch based on the
   [official documentation](https://github.com/IogaMaster/neocord)
 
+- Added support for css and tailwindcss through vscode-language-servers-extracted & tailwind-language-server.
+  Those can be enabled through `vim.languages.css` and `vim.languages.tailwind`
+
 [donnerinoern](https://github.com/donnerinoern):
 
 - Added Gruvbox theme

--- a/modules/languages/css.nix
+++ b/modules/languages/css.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib) mkEnableOption mkOption mkIf mkMerge isList types nvim;
+
+  cfg = config.vim.languages.css;
+
+  defaultServer = "vscode-langservers-extracted";
+  servers = {
+    vscode-langservers-extracted = {
+      package = pkgs.nodePackages.vscode-langservers-extracted;
+      lspConfig = ''
+        -- enable (broadcasting) snippet capability for completion
+        -- see <https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#cssls>
+        local css_capabilities = vim.lsp.protocol.make_client_capabilities()
+        css_capabilities.textDocument.completion.completionItem.snippetSupport = true
+
+        -- cssls setup
+        lspconfig.cssls.setup {
+          capabilities = css_capabilities;
+          on_attach = default_on_attach;
+          cmd = ${
+          if isList cfg.lsp.package
+          then nvim.lua.expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/vscode-css-language-server", "--stdio"}''
+        }
+        }
+      '';
+    };
+  };
+in {
+  options.vim.languages.css = {
+    enable = mkEnableOption "CSS language support";
+
+    treesitter = {
+      enable = mkEnableOption "CSS treesitter" // {default = config.vim.languages.enableTreesitter;};
+
+      package = nvim.types.mkGrammarOption pkgs "css";
+    };
+
+    lsp = {
+      enable = mkEnableOption "CSS LSP support" // {default = config.vim.languages.enableLSP;};
+
+      server = mkOption {
+        description = "CSS LSP server to use";
+        type = with types; enum (attrNames servers);
+        default = defaultServer;
+      };
+
+      package = mkOption {
+        description = "CSS LSP server package, or the command to run as a list of strings";
+        example = ''[lib.getExe pkgs.jdt-language-server " - data " " ~/.cache/jdtls/workspace "]'';
+        type = with types; either package (listOf str);
+        default = servers.${cfg.lsp.server}.package;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.tailwindcss-lsp = servers.${cfg.lsp.server}.lspConfig;
+    })
+  ]);
+}

--- a/modules/languages/default.nix
+++ b/modules/languages/default.nix
@@ -2,26 +2,28 @@
   inherit (lib.nvim.languages) mkEnable;
 in {
   imports = [
-    ./markdown
-    ./tidal
+    ./bash
     ./dart
     ./elixir
-    ./bash
+    ./markdown
+    ./tidal
 
     ./clang.nix
+    ./css.nix
     ./go.nix
+    ./html.nix
+    ./java.nix
+    ./lua.nix
     ./nix.nix
+    ./php.nix
     ./python.nix
     ./rust.nix
     ./sql.nix
+    ./svelte.nix
+    ./tailwind.nix
+    ./terraform.nix
     ./ts.nix
     ./zig.nix
-    ./html.nix
-    ./svelte.nix
-    ./java.nix
-    ./lua.nix
-    ./php.nix
-    ./terraform.nix
   ];
 
   options.vim.languages = {

--- a/modules/languages/tailwind.nix
+++ b/modules/languages/tailwind.nix
@@ -1,0 +1,57 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib) mkEnableOption mkOption mkIf mkMerge isList types nvim;
+
+  cfg = config.vim.languages.tailwind;
+
+  defaultServer = "tailwindcss-language-server";
+  servers = {
+    tailwindcss-language-server = {
+      package = pkgs.tailwindcss-language-server;
+      lspConfig = ''
+        lspconfig.tailwindcss.setup {
+          capabilities = capabilities;
+          on_attach = default_on_attach;
+          cmd = ${
+          if isList cfg.lsp.package
+          then nvim.lua.expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/tailwindcss-language-server", "--stdio"}''
+        }
+        }
+      '';
+    };
+  };
+in {
+  options.vim.languages.tailwind = {
+    enable = mkEnableOption "Tailwindcss language support";
+
+    lsp = {
+      enable = mkEnableOption "Tailwindcss LSP support" // {default = config.vim.languages.enableLSP;};
+
+      server = mkOption {
+        description = "Tailwindcss LSP server to use";
+        type = with types; enum (attrNames servers);
+        default = defaultServer;
+      };
+
+      package = mkOption {
+        description = "Tailwindcss LSP server package, or the command to run as a list of strings";
+        example = ''[lib.getExe pkgs.jdt-language-server " - data " " ~/.cache/jdtls/workspace "]'';
+        type = with types; either package (listOf str);
+        default = servers.${cfg.lsp.server}.package;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.css-lsp = servers.${cfg.lsp.server}.lspConfig;
+    })
+  ]);
+}


### PR DESCRIPTION
Adds support for CSS and Tailwindcss.

From what I can tell, Tailwindcss likely depends on css treesitter, but I do not want those two modules to be codependent on each other.