### PR TITLE
statusline/lualine: avoid hardcoding config options

### DIFF
--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -12,6 +12,14 @@ Release notes for release 0.6
 
 - Fixed empty winbar when breadcrumbs are disabled
 
+[donnerinoern](https://github.com/donnerinoern):
+
+- Added Gruvbox theme
+
+- Added marksman LSP for Markdown
+
+- Fixed markdown preview with Glow not working and added an option for changing the preview keybind
+
 [notashelf](https://github.com/notashelf):
 
 - Finished moving to `nixosOptionsDoc` in the documentation and changelog. We are fully free of asciidoc now
@@ -25,10 +33,10 @@ Release notes for release 0.6
 - Added support for css and tailwindcss through vscode-language-servers-extracted & tailwind-language-server.
   Those can be enabled through `vim.languages.css` and `vim.languages.tailwind`
 
-[donnerinoern](https://github.com/donnerinoern):
+- Lualine module now allows customizing `always_divide_middle`, `ignore_focus` and `disabled_filetypes` through the new
+  options: [vim.statusline.lualine.alwaysDivideMiddle](vim.statusline.lualine.alwaysDivideMiddle),
+  [vim.statusline.lualine.ignoreFocus](vim.statusline.lualine.ignoreFocus) and
+  [vim.statusline.lualine.disabledFiletypes](vim.statusline.lualine.disabledFiletypes)
 
-- Added Gruvbox theme
-
-- Added marksman LSP for Markdown
-
-- Fixed Markdown-previewer Glow not working and added an option for changing the preview keybind
+- Updated all plugin inputs to their latest versions (26.01.2024) - this brought minor color changess to the Catppuccin
+  theme

--- a/modules/statusline/lualine/config.nix
+++ b/modules/statusline/lualine/config.nix
@@ -20,10 +20,10 @@ in {
           theme = "${cfg.theme}",
           component_separators = {"${cfg.componentSeparator.left}","${cfg.componentSeparator.right}"},
           section_separators = {"${cfg.sectionSeparator.left}","${cfg.sectionSeparator.right}"},
-          disabled_filetypes = { 'alpha' },
-          always_divide_middle = true,
+          disabled_filetypes = ${nvim.lua.listToLuaTable cfg.disabledFiletypes},
+          always_divide_middle = ${boolToString cfg.alwaysDivideMiddle},
           globalstatus = ${boolToString cfg.globalStatus},
-          ignore_focus = {'NvimTree'},
+          ignore_focus = ${nvim.lua.listToLuaTable cfg.ignoreFocus},
           extensions = {${optionalString config.vim.filetree.nvimTree.enable "'nvim-tree'"}},
           refresh = {
             statusline = ${toString cfg.refresh.statusline},
@@ -31,6 +31,7 @@ in {
             winbar = ${toString cfg.refresh.winbar},
           },
         },
+
         -- active sections
         sections = {
           lualine_a = ${nvim.lua.luaTable (cfg.activeSection.a ++ cfg.extraActiveSection.a)},
@@ -40,7 +41,8 @@ in {
           lualine_y = ${nvim.lua.luaTable (cfg.activeSection.y ++ cfg.extraActiveSection.y)},
           lualine_z = ${nvim.lua.luaTable (cfg.activeSection.z ++ cfg.extraActiveSection.z)},
         },
-        --
+
+        -- inactive sections
         inactive_sections = {
           lualine_a = ${nvim.lua.luaTable (cfg.inactiveSection.a ++ cfg.extraInactiveSection.a)},
           lualine_b = ${nvim.lua.luaTable (cfg.inactiveSection.b ++ cfg.extraInactiveSection.b)},
@@ -49,9 +51,12 @@ in {
           lualine_y = ${nvim.lua.luaTable (cfg.inactiveSection.y ++ cfg.extraInactiveSection.y)},
           lualine_z = ${nvim.lua.luaTable (cfg.inactiveSection.z ++ cfg.extraInactiveSection.z)},
         },
+
+        -- tabline (currently unsupported)
         tabline = {},
 
         ${optionalString (breadcrumbsCfg.enable && breadcrumbsCfg.source == "nvim-navic") ''
+        -- enable winbar if nvim-navic is enabled
         winbar = {
           lualine_c = {
             {

--- a/modules/statusline/lualine/lualine.nix
+++ b/modules/statusline/lualine/lualine.nix
@@ -24,11 +24,13 @@ in {
         description = "Refresh rate for lualine";
         default = 1000;
       };
+
       tabline = mkOption {
         type = types.int;
         description = "Refresh rate for tabline";
         default = 1000;
       };
+
       winbar = mkOption {
         type = types.int;
         description = "Refresh rate for winbar";
@@ -40,6 +42,27 @@ in {
       type = types.bool;
       description = "Enable global status for lualine";
       default = true;
+    };
+
+    alwaysDivideMiddle = mkOption {
+      type = types.bool;
+      description = "Always divide middle section";
+      default = true;
+    };
+
+    disabledFiletypes = mkOption {
+      type = with types; listOf str;
+      description = "Filetypes to disable lualine on";
+      default = ["alpha"];
+    };
+
+    ignoreFocus = mkOption {
+      type = with types; listOf str;
+      default = ["NvimTree"];
+      description = ''
+        If current filetype is in this list it'll always be drawn as inactive statusline
+        and the last window will be drawn as active statusline.
+      '';
     };
 
     theme = let
@@ -175,6 +198,9 @@ in {
                 bg='${colorPuccin}',
                 fg='lavender'
               },
+              separator = {
+                right = ''
+              },
             }
           ''
         ];
@@ -220,6 +246,9 @@ in {
               end,
               icon = ' ',
               color = {bg='${colorPuccin}', fg='lavender'},
+              separator = {
+                left = '',
+              },
             }
           ''
           ''


### PR DESCRIPTION
Adds module options for `always_divide_middle`, `ignore_focus` and `disabled_filetypes` configuration options of Lualine.