### PR TITLE
ui/colorizer: rebase on maintained fork

### DIFF
--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -20,6 +20,8 @@ Release notes for release 0.6
 
 - Fixed markdown preview with Glow not working and added an option for changing the preview keybind
 
+- colorizer.nvim: switched to a maintained fork
+
 [notashelf](https://github.com/notashelf):
 
 - Finished moving to `nixosOptionsDoc` in the documentation and changelog. We are fully free of asciidoc now

--- a/flake.lock
+++ b/flake.lock
@@ -1063,15 +1063,15 @@
     "nvim-colorizer-lua": {
       "flake": false,
       "locked": {
-        "lastModified": 1591879145,
-        "narHash": "sha256-6YrnItxExL2C8pNIdLd+hXCjsB2MbZANwWkah6dreD8=",
-        "owner": "norcalli",
+        "lastModified": 1703321305,
+        "narHash": "sha256-oKvFN2K+ASlPNwj2rhptR/ErYgo6XKBPhXSZotDdCP0=",
+        "owner": "NvChad",
         "repo": "nvim-colorizer.lua",
-        "rev": "36c610a9717cc9ec426a07c8e6bf3b3abcb139d6",
+        "rev": "85855b38011114929f4058efc97af1059ab3e41d",
         "type": "github"
       },
       "original": {
-        "owner": "norcalli",
+        "owner": "NvChad",
         "repo": "nvim-colorizer.lua",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -520,7 +520,7 @@
     };
 
     nvim-colorizer-lua = {
-      url = "github:norcalli/nvim-colorizer.lua";
+      url = "github:NvChad/nvim-colorizer.lua";
       flake = false;
     };
 

--- a/modules/ui/colorizer/colorizer.nix
+++ b/modules/ui/colorizer/colorizer.nix
@@ -8,6 +8,15 @@ in {
   options.vim.ui.colorizer = {
     enable = mkEnableOption "nvim-colorizer.lua for color highlighting";
 
+    filetypes = mkOption {
+      type = with types; attrsOf attrs;
+      default = {
+        css = {};
+        scss = {};
+      };
+      description = "Filetypes to highlight on";
+    };
+
     options = {
       rgb = mkOption {
         type = types.bool;
@@ -47,7 +56,7 @@ in {
 
       css = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = "Enable all CSS features: rgb_fn, hsl_fn, names, RGB, RRGGBB";
       };
 
@@ -61,6 +70,24 @@ in {
         type = types.enum ["foreground" "background"];
         default = "background";
         description = "Set the display mode";
+      };
+
+      tailwind = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable tailwind colors";
+      };
+
+      sass = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable sass colors";
+      };
+
+      alwaysUpdate = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Update color values even if buffer is not focused, like when using cmp_menu, cmp_docs";
       };
     };
   };

--- a/modules/ui/colorizer/config.nix
+++ b/modules/ui/colorizer/config.nix
@@ -15,16 +15,20 @@ in {
 
     vim.luaConfigRC.colorizer = nvim.dag.entryAnywhere ''
       require('colorizer').setup({
-         DEFAULT_OPTIONS = {
-           RGB      = ${boolToString cfg.options.rgb};
-           RRGGBB   = ${boolToString cfg.options.rrggbb};
-           names    = ${boolToString cfg.options.names};
-           RRGGBBAA = ${boolToString cfg.options.rrggbbaa};
-           rgb_fn   = ${boolToString cfg.options.rgb_fn};
-           hsl_fn   = ${boolToString cfg.options.hsl_fn};
-           css      = ${boolToString cfg.options.css};
-           css_fn   = ${boolToString cfg.options.css_fn};
-           mode     = '${toString cfg.options.mode}';
+        filetypes = ${nvim.lua.attrsetToLuaTable cfg.filetypes},
+        user_default_options = {
+          RGB           = ${boolToString cfg.options.rgb};
+          RRGGBB        = ${boolToString cfg.options.rrggbb};
+          names         = ${boolToString cfg.options.names};
+          RRGGBBAA      = ${boolToString cfg.options.rrggbbaa};
+          rgb_fn        = ${boolToString cfg.options.rgb_fn};
+          hsl_fn        = ${boolToString cfg.options.hsl_fn};
+          css           = ${boolToString cfg.options.css};
+          css_fn        = ${boolToString cfg.options.css_fn};
+          mode          = '${toString cfg.options.mode}';
+          tailwind      = ${boolToString cfg.options.tailwind};
+          sass          = ${boolToString cfg.options.tailwind};
+          always_update = ${boolToString cfg.options.alwaysUpdate};
         }
       })
     '';


### PR DESCRIPTION
# Description

~~Added a new option for colorizer which, when enabled, will attach colorizer to any buffer with a filetype set in autoAttach.filetypes. I also fixed the indentation on colorizer's DEFAULT_OPTIONS.~~

Rebased colorizer.nvim on a maintained fork and updated the options accordingly.

## Type of change

- New feature

## Checklist

- [x] My code follows the style and contributing guidelines of this project.
- [x] I ran Alejandra to format my code (`nix fmt`).
- [x] I have performed a self-review of my own code and tested it.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] This change requires a documentation update.
- [ ] I have updated the documentation accordingly.

## Screenshots & Logs

![image](https://github.com/NotAShelf/neovim-flake/assets/72634505/9fd9200d-1018-4845-9980-79b1b15e478b)

