### PR TITLE
dashboard/startify: fix invalid reference to "neovimPlugins"

### DIFF
--- a/modules/dashboard/startify/config.nix
+++ b/modules/dashboard/startify/config.nix
@@ -4,17 +4,13 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf;
+  inherit (lib) mkIf nvim;
+  inherit (nvim.vim) mkVimBool;
 
   cfg = config.vim.dashboard.startify;
-
-  mkVimBool = val:
-    if val
-    then "1"
-    else "0";
 in {
-  config = mkIf (cfg.enable) {
-    vim.startPlugins = with pkgs.neovimPlugins; [vim-startify];
+  config = mkIf cfg.enable {
+    vim.startPlugins = with pkgs.vimPlugins; [vim-startify];
 
     vim.globals = {
       "startify_custom_header" =


### PR DESCRIPTION
For some reason I've used `pkgs.neovimPlugins` instead of `pkgs.vimPlugins`. There is no such thing as `pkgs.neovimPlugins`.

Closes #208
