### PR TITLE
docs: add missing documentation entry; define renamed options

### DIFF
--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -22,6 +22,8 @@ Release notes for release 0.6
 
 - colorizer.nvim: switched to a maintained fork
 
+- Added `markdown-preview.nvim`, moved `glow.nvim` to a brand new `vim.utility.preview` category.
+
 [notashelf](https://github.com/notashelf):
 
 - Finished moving to `nixosOptionsDoc` in the documentation and changelog. We are fully free of asciidoc now

--- a/modules/utility/preview/glow/glow.nix
+++ b/modules/utility/preview/glow/glow.nix
@@ -1,12 +1,14 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption mkMappingOption;
+  inherit (lib) mkEnableOption mkMappingOption mkRenamedOptionModule;
 in {
+  imports = [
+    (mkRenamedOptionModule ["vim" "languages" "markdown" "glow" "enable"] ["vim" "utility" "preview" "glow" "enable"])
+  ];
+
   options.vim.utility.preview = {
     glow = {
       enable = mkEnableOption "markdown preview in neovim with glow";
-      mappings = {
-        openPreview = mkMappingOption "Open preview" "<leader>p";
-      };
+      mappings.openPreview = mkMappingOption "Open preview" "<leader>p";
     };
   };
 }


### PR DESCRIPTION
Adds the missing documentation entry for #217, and ensures the changes are backwards compatible through the usage of `mkRenamedOptionModule` to warn the users that have the old option still defined instead of erroring out.