### PR TITLE
wrapper: provide option to wrap neovim with extra lua packages

### DIFF
--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -48,3 +48,7 @@ Release notes for release 0.6
 [elijahimmer](https://github.com/elijahimmer)
 
 - Added rose-pine theme
+
+[frothymarrow](https://github.com/frothymarrow)
+
+- Added option `vim.luaPackages` to wrap neovim with extra Lua packages.

--- a/modules/core/default.nix
+++ b/modules/core/default.nix
@@ -209,6 +209,14 @@ in {
           }'';
       };
 
+      luaPackages = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          List of lua packages to install.
+        '';
+      };
+
       globals = mkOption {
         default = {};
         description = "Set containing global variable values";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -23,6 +23,8 @@ inputs: {
 
   vimOptions = module.config.vim;
 
+  extraLuaPackages = ps: map (x: ps.${x}) vimOptions.luaPackages;
+
   buildPlug = {pname, ...} @ args:
     assert lib.asserts.assertMsg (pname != "nvim-treesitter") "Use buildTreesitterPlug for building nvim-treesitter.";
       buildVimPlugin (args
@@ -58,6 +60,8 @@ inputs: {
   neovim = wrapNeovim vimOptions.package {
     inherit (vimOptions) viAlias;
     inherit (vimOptions) vimAlias;
+
+    inherit extraLuaPackages;
 
     configure = {
       customRC = vimOptions.builtConfigRC;


### PR DESCRIPTION
Introduces a `vim.luaPackages` option to be passed to the wrapper to include additional Lua packages.