### PR TITLE
images/image-nvim: remove assert for `ueberzug` backend on darwin

### DIFF
--- a/modules/utility/images/image-nvim/config.nix
+++ b/modules/utility/images/image-nvim/config.nix
@@ -11,13 +11,6 @@
   cfg = config.vim.utility.images.image-nvim;
 in {
   config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = pkgs.stdenv.isDarwin && cfg.setupOpts.backend != "ueberzug";
-        message = "image-nvim: ueberzug backend is broken on ${pkgs.stdenv.hostPlatform.system}. if you are using kitty, please set `vim.utility.images.image-nvim.setupOpts.backend` option to `kitty` in your configuration, otherwise disable this module.";
-      }
-    ];
-
     vim = {
       startPlugins = [
         "image-nvim"


### PR DESCRIPTION
The assert was added because in my testing `ueberzug` backend was not working in Neovim. 

After several wasted hours of digging through the source code of `ueberzugpp`, found out that `iterm2` image protocol included in Wezterm (internally used by `ueberzugpp`) is not supported by `image.nvim`. Taking a look at the closed issues, found the issue about it https://github.com/3rd/image.nvim/issues/86.

I still chose to keep the option disabled in all default configurations as it requires an external program and still might abort on some terminals such as Alacritty.