### PR TITLE
treewide: make lib calls explicit

### DIFF
--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -8,13 +8,16 @@
 #  - the addition of the function `entryBefore` indicating a "wanted
 #    by" relationship.
 {lib}: let
-  inherit (lib) all filterAttrs nvim mapAttrs toposort;
+  inherit (builtins) isAttrs attrValues attrNames elem all;
+  inherit (lib.attrsets) filterAttrs mapAttrs;
+  inherit (lib.lists) toposort;
+  inherit (lib.nvim.dag) isEntry entryBetween;
 in {
   empty = {};
 
   isEntry = e: e ? data && e ? after && e ? before;
   isDag = dag:
-    builtins.isAttrs dag && all nvim.dag.isEntry (builtins.attrValues dag);
+    isAttrs dag && all isEntry (attrValues dag);
 
   /*
   Takes an attribute set containing entries built by entryAnywhere,
@@ -76,8 +79,8 @@ in {
   */
   topoSort = dag: let
     dagBefore = dag: name:
-      builtins.attrNames
-      (filterAttrs (_n: v: builtins.elem name v.before) dag);
+      attrNames
+      (filterAttrs (_n: v: elem name v.before) dag);
     normalizedDag =
       mapAttrs (n: v: {
         name = n;
@@ -85,8 +88,8 @@ in {
         after = v.after ++ dagBefore dag n;
       })
       dag;
-    before = a: b: builtins.elem a.name b.after;
-    sorted = toposort before (builtins.attrValues normalizedDag);
+    before = a: b: elem a.name b.after;
+    sorted = toposort before (attrValues normalizedDag);
   in
     if sorted ? result
     then {
@@ -100,8 +103,8 @@ in {
   entryBetween = before: after: data: {inherit data before after;};
 
   # Create a DAG entry with no particular dependency information.
-  entryAnywhere = nvim.dag.entryBetween [] [];
+  entryAnywhere = entryBetween [] [];
 
-  entryAfter = nvim.dag.entryBetween [];
-  entryBefore = before: nvim.dag.entryBetween before [];
+  entryAfter = entryBetween [];
+  entryBefore = before: entryBetween before [];
 }

--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -1,32 +1,37 @@
 # From home-manager: https://github.com/nix-community/home-manager/blob/master/modules/lib/booleans.nix
-{lib}: {
+{lib}: let
+  inherit (builtins) isString getAttr;
+  inherit (lib.options) mkOption;
+  inherit (lib.attrsets) listToAttrs;
+  inherit (lib.types) bool;
+in {
   # Converts a boolean to a yes/no string. This is used in lots of
   # configuration formats.
   diagnosticsToLua = {
     lang,
     config,
-    diagnostics,
+    diagnosticsProviders,
   }:
-    lib.listToAttrs
+    listToAttrs
     (map (v: let
         type =
-          if builtins.isString v
+          if isString v
           then v
-          else builtins.getAttr v.type;
+          else getAttr v.type;
         package =
-          if builtins.isString v
-          then diagnostics.${type}.package
+          if isString v
+          then diagnosticsProviders.${type}.package
           else v.package;
       in {
         name = "${lang}-diagnostics-${type}";
-        value = diagnostics.${type}.nullConfig package;
+        value = diagnosticsProviders.${type}.nullConfig package;
       })
       config);
 
   mkEnable = desc:
-    lib.mkOption {
+    mkOption {
       description = "Turn on ${desc} for enabled languages by default";
-      type = lib.types.bool;
+      type = bool;
       default = false;
     };
 }

--- a/lib/types/languages.nix
+++ b/lib/types/languages.nix
@@ -15,13 +15,13 @@ with lib; let
 in {
   diagnostics = {
     langDesc,
-    diagnostics,
-    defaultDiagnostics,
+    diagnosticsProviders,
+    defaultDiagnosticsProvider,
   }:
     mkOption {
       description = "List of ${langDesc} diagnostics to enable";
-      type = with types; listOf (either (enum (attrNames diagnostics)) (submodule diagnosticSubmodule));
-      default = defaultDiagnostics;
+      type = with types; listOf (either (enum (attrNames diagnosticsProviders)) (submodule diagnosticSubmodule));
+      default = defaultDiagnosticsProvider;
     };
 
   mkGrammarOption = pkgs: grammar:

--- a/lib/vim.nix
+++ b/lib/vim.nix
@@ -1,5 +1,5 @@
 let
-  inherit (builtins) isInt isBool toJSON;
+  inherit (builtins) isInt isBool toJSON toString;
 in rec {
   # yes? no.
   yesNo = value:
@@ -16,7 +16,7 @@ in rec {
   # convert a literal value to a vim compliant value
   valToVim = val:
     if (isInt val)
-    then (builtins.toString val)
+    then (toString val)
     else
       (
         if (isBool val)

--- a/modules/basic/config.nix
+++ b/modules/basic/config.nix
@@ -4,12 +4,15 @@
   ...
 }: let
   inherit (builtins) concatStringsSep;
-  inherit (lib) optionalString mkIf nvim;
+  inherit (lib.modules) mkIf;
+  inherit (lib.lists) optionals;
+  inherit (lib.strings) optionalString;
+  inherit (lib.nvim.dag) entryAfter;
 
   cfg = config.vim;
 in {
   config = {
-    vim.startPlugins = ["plenary-nvim"] ++ lib.optionals (cfg.spellChecking.enableProgrammingWordList) ["vim-dirtytalk"];
+    vim.startPlugins = ["plenary-nvim"] ++ optionals (cfg.spellChecking.enableProgrammingWordList) ["vim-dirtytalk"];
 
     vim.maps.normal =
       mkIf cfg.disableArrows {
@@ -57,7 +60,7 @@ in {
       };
     };
 
-    vim.configRC.basic = nvim.dag.entryAfter ["globalsScript"] ''
+    vim.configRC.basic = entryAfter ["globalsScript"] ''
       " Settings that are set for everything
       set encoding=utf-8
       set mouse=${cfg.mouseSupport}

--- a/modules/basic/module.nix
+++ b/modules/basic/module.nix
@@ -3,12 +3,12 @@
   lib,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption;
-  inherit (lib.types) types;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) package path str bool int listOf enum nullOr;
 in {
   options.vim = {
     package = mkOption {
-      type = types.package;
+      type = package;
       default = pkgs.neovim-unwrapped;
       description = ''
         The neovim package to use. You will need to use an unwrapped package for this option to work as intended.
@@ -18,13 +18,13 @@ in {
     debugMode = {
       enable = mkEnableOption "debug mode";
       level = mkOption {
-        type = types.int;
+        type = int;
         default = 20;
         description = "Set the debug level";
       };
 
       logFile = mkOption {
-        type = types.path;
+        type = path;
         default = "/tmp/nvim.log";
         description = "Set the log file";
       };
@@ -33,7 +33,7 @@ in {
     enableLuaLoader = mkEnableOption "experimental Lua module loader to speed up the start up process";
 
     leaderKey = mkOption {
-      type = with types; nullOr str;
+      type = nullOr str;
       default = null;
       description = "The leader key to be used internally";
     };
@@ -42,7 +42,7 @@ in {
       enable = mkEnableOption "neovim's built-in spellchecking";
       enableProgrammingWordList = mkEnableOption "vim-dirtytalk, a wordlist for programmers, that includes programming words";
       languages = mkOption {
-        type = with types; listOf str;
+        type = listOf str;
         description = "The languages to be used for spellchecking";
         default = ["en"];
         example = ["en" "de"];
@@ -50,55 +50,55 @@ in {
     };
 
     colourTerm = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Set terminal up for 256 colours";
     };
 
     disableArrows = mkOption {
-      type = types.bool;
+      type = bool;
       default = false;
       description = "Set to prevent arrow keys from moving cursor";
     };
 
     hideSearchHighlight = mkOption {
-      type = types.bool;
+      type = bool;
       default = false;
       description = "Hide search highlight so it doesn't stay highlighted";
     };
 
     scrollOffset = mkOption {
-      type = types.int;
+      type = int;
       default = 8;
       description = "Start scrolling this number of lines from the top or bottom of the page.";
     };
 
     wordWrap = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Enable word wrapping.";
     };
 
     syntaxHighlighting = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Enable syntax highlighting";
     };
 
     mapLeaderSpace = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Map the space key to leader key";
     };
 
     useSystemClipboard = mkOption {
-      type = types.bool;
+      type = bool;
       default = false;
       description = "Make use of the clipboard for default yank and paste operations. Don't use * and +";
     };
 
     mouseSupport = mkOption {
-      type = with types; enum ["a" "n" "v" "i" "c"];
+      type = enum ["a" "n" "v" "i" "c"];
       default = "a";
       description = ''
         Set modes for mouse support.
@@ -112,7 +112,7 @@ in {
     };
 
     lineNumberMode = mkOption {
-      type = with types; enum ["relative" "number" "relNumber" "none"];
+      type = enum ["relative" "number" "relNumber" "none"];
       default = "relNumber";
       description = ''
         How line numbers are displayed. Available options are
@@ -121,78 +121,78 @@ in {
     };
 
     preventJunkFiles = mkOption {
-      type = types.bool;
+      type = bool;
       default = false;
       description = "Prevent swapfile, backupfile from being created";
     };
 
     tabWidth = mkOption {
-      type = types.int;
+      type = int;
       default = 4;
       description = "Set the width of tabs";
     };
 
     autoIndent = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Enable auto indent";
     };
 
     cmdHeight = mkOption {
-      type = types.int;
+      type = int;
       default = 1;
       description = "Height of the command pane";
     };
 
     updateTime = mkOption {
-      type = types.int;
+      type = int;
       default = 300;
       description = "The number of milliseconds till Cursor Hold event is fired";
     };
 
     showSignColumn = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Show the sign column";
     };
 
     bell = mkOption {
-      type = types.enum ["none" "visual" "on"];
+      type = enum ["none" "visual" "on"];
       default = "none";
       description = "Set how bells are handled. Options: on, visual or none";
     };
 
     mapTimeout = mkOption {
-      type = types.int;
+      type = int;
       default = 500;
       description = "Timeout in ms that neovim will wait for mapped action to complete";
     };
 
     splitBelow = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "New splits will open below instead of on top";
     };
 
     splitRight = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "New splits will open to the right";
     };
     enableEditorconfig = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Follow editorconfig rules in current directory";
     };
 
     cursorlineOpt = mkOption {
-      type = types.enum ["line" "screenline" "number" "both"];
+      type = enum ["line" "screenline" "number" "both"];
       default = "line";
       description = "Highlight the text line of the cursor with CursorLine hl-CursorLine";
     };
 
     searchCase = mkOption {
-      type = types.enum ["ignore" "smart" "sensitive"];
+      type = enum ["ignore" "smart" "sensitive"];
       default = "sensitive";
       description = "Set the case sensitivity of search";
     };

--- a/modules/completion/nvim-cmp/nvim-cmp.nix
+++ b/modules/completion/nvim-cmp/nvim-cmp.nix
@@ -1,5 +1,5 @@
 {lib, ...}: let
-  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.options) mkEnableOption mkOption literalMD;
   inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.types) enum attrsOf nullOr str;
 in {
@@ -52,7 +52,7 @@ in {
           '';
           type = str;
           default = "nvim_cmp_menu_map";
-          example = lib.literalMD ''
+          example = literalMD ''
             ```lua
             function(entry, vim_item)
               return vim_item

--- a/modules/dashboard/dashboard-nvim/dashboard-nvim.nix
+++ b/modules/dashboard/dashboard-nvim/dashboard-nvim.nix
@@ -1,5 +1,5 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption;
+  inherit (lib.options) mkEnableOption;
 in {
   options.vim.dashboard.dashboard-nvim = {
     enable = mkEnableOption "Fancy and Blazing Fast start screen plugin of neovim [dashboard.nvim]";

--- a/modules/filetree/nvimtree/config.nix
+++ b/modules/filetree/nvimtree/config.nix
@@ -33,7 +33,7 @@ in {
 
     vim.luaConfigRC.nvimtreelua = entryAnywhere ''
       ${
-        lib.optionalString cfg.disableNetrw ''
+        optionalString cfg.disableNetrw ''
           -- disable netrew completely
           vim.g.loaded_netrw = 1
           vim.g.loaded_netrwPlugin = 1

--- a/modules/filetree/nvimtree/nvimtree.nix
+++ b/modules/filetree/nvimtree/nvimtree.nix
@@ -3,29 +3,30 @@
   lib,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption types literalExpression;
+  inherit (lib.options) mkEnableOption mkOption literalExpression;
+  inherit (lib.types) nullOr str bool int listOf enum attrs oneOf addCheck submodule;
 in {
   options.vim.filetree.nvimTree = {
     enable = mkEnableOption "filetree via nvim-tree.lua";
 
     mappings = {
       toggle = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "<leader>t";
         description = "Toggle NvimTree";
       };
       refresh = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "<leader>tr";
         description = "Refresh NvimTree";
       };
       findFile = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "<leader>tg";
         description = "Find file in NvimTree";
       };
       focus = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "<leader>tf";
         description = "Focus NvimTree";
       };
@@ -34,19 +35,19 @@ in {
     disableNetrw = mkOption {
       default = false;
       description = "Disables netrw and replaces it with tree";
-      type = types.bool;
+      type = bool;
     };
 
     hijackNetrw = mkOption {
       default = true;
       description = "Prevents netrw from automatically opening when opening directories";
-      type = types.bool;
+      type = bool;
     };
 
     autoreloadOnWrite = mkOption {
       default = true;
       description = "Auto reload tree on write";
-      type = types.bool;
+      type = bool;
     };
 
     updateFocusedFile = mkOption {
@@ -55,16 +56,16 @@ in {
         until it finds the file.
       '';
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           enable = mkOption {
-            type = types.bool;
+            type = bool;
             default = false;
             description = "update focused file";
           };
 
           updateRoot = mkOption {
-            type = types.bool;
+            type = bool;
             default = false;
             description = ''
               Update the root directory of the tree if the file is not under current
@@ -75,7 +76,7 @@ in {
           };
 
           ignoreList = mkOption {
-            type = with types; listOf str;
+            type = listOf str;
             default = [];
             description = ''
               List of buffer names and filetypes that will not update the root dir
@@ -93,26 +94,26 @@ in {
       sorter = mkOption {
         default = "name";
         description = "How files within the same directory are sorted.";
-        type = types.enum ["name" "extension" "modification_time" "case_sensitive" "suffix" "filetype"];
+        type = enum ["name" "extension" "modification_time" "case_sensitive" "suffix" "filetype"];
       };
 
       foldersFirst = mkOption {
         default = true;
         description = "Sort folders before files. Has no effect when `sort.sorter` is a function.";
-        type = types.bool;
+        type = bool;
       };
     };
 
     hijackCursor = mkOption {
       default = false;
       description = "Hijack the cursor in the tree to put it at the start of the filename";
-      type = types.bool;
+      type = bool;
     };
 
     hijackUnnamedBufferWhenOpening = mkOption {
       default = false;
       description = "Open nvimtree in place of the unnamed buffer if it's empty.";
-      type = types.bool;
+      type = bool;
     };
 
     rootDirs = mkOption {
@@ -120,7 +121,7 @@ in {
       description = ''
         Preferred root directories. Only relevant when `updateFocusedFile.updateRoot` is `true`
       '';
-      type = with types; listOf str;
+      type = listOf str;
     };
 
     preferStartupRoot = mkOption {
@@ -129,11 +130,11 @@ in {
         Prefer startup root directory when updating root directory of the tree.
         Only relevant when `update_focused_file.update_root` is `true`
       '';
-      type = types.bool;
+      type = bool;
     };
 
     syncRootWithCwd = mkOption {
-      type = types.bool;
+      type = bool;
       default = false;
       description = ''
         Changes the tree root directory on `DirChanged` and refreshes the tree.
@@ -145,13 +146,13 @@ in {
 
     reloadOnBufEnter = mkOption {
       default = false;
-      type = types.bool;
+      type = bool;
       description = "Automatically reloads the tree on `BufEnter` nvim-tree.";
     };
 
     respectBufCwd = mkOption {
       default = false;
-      type = types.bool;
+      type = bool;
       description = "Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.";
     };
 
@@ -163,10 +164,10 @@ in {
         autoOpen = false;
       };
 
-      type = types.submodule {
+      type = submodule {
         options = {
           enable = mkOption {
-            type = types.bool;
+            type = bool;
             description = ''
               Enable the `hijack_directories` feature. Disable this option if you use vim-dirvish or dirbuf.nvim.
               If `hijack_netrw` and `disable_netrw` are `false`, this feature will be disabled.
@@ -174,7 +175,7 @@ in {
           };
 
           autoOpen = mkOption {
-            type = types.bool;
+            type = bool;
             description = ''
               Opens the tree if the tree was previously closed.
             '';
@@ -187,7 +188,7 @@ in {
       args = mkOption {
         default = [];
         description = "Optional argument list.";
-        type = with types; listOf str;
+        type = listOf str;
       };
 
       cmd = mkOption {
@@ -198,7 +199,7 @@ in {
           then "${pkgs.xdg-utils}/bin/xdg-open"
           else throw "NvimTree: No default system open command for this platform, please set `vim.filetree.nvimTree.systemOpen.cmd`";
         description = "The open command itself";
-        type = types.str;
+        type = str;
       };
     };
 
@@ -210,13 +211,13 @@ in {
 
       default = {};
 
-      type = types.submodule {
+      type = submodule {
         options = {
           enable = mkEnableOption "diagnostics view in the signcolumn.";
 
           debounceDelay = mkOption {
             description = "Idle milliseconds between diagnostic event and update.";
-            type = types.int;
+            type = int;
             default = 50;
           };
 
@@ -226,7 +227,7 @@ in {
           };
 
           showOnOpenDirs = mkOption {
-            type = types.bool;
+            type = bool;
             default = true;
             description = ''
               Show diagnostics icons on directories that are open.
@@ -237,26 +238,26 @@ in {
           icons = mkOption {
             description = "Icons for diagnostic severity.";
             default = {};
-            type = types.submodule {
+            type = submodule {
               options = {
                 hint = mkOption {
                   description = "Icon used for `hint` diagnostic.";
-                  type = types.str;
+                  type = str;
                   default = "";
                 };
                 info = mkOption {
                   description = "Icon used for `info` diagnostic.";
-                  type = types.str;
+                  type = str;
                   default = "";
                 };
                 warning = mkOption {
                   description = "Icon used for `warning` diagnostic.";
-                  type = types.str;
+                  type = str;
                   default = "";
                 };
                 error = mkOption {
                   description = "Icon used for `error` diagnostic.";
-                  type = types.str;
+                  type = str;
                   default = "";
                 };
               };
@@ -266,17 +267,17 @@ in {
           severity = mkOption {
             description = "Severity for which the diagnostics will be displayed. See `:help diagnostic-severity`";
             default = {};
-            type = types.submodule {
+            type = submodule {
               options = {
                 min = mkOption {
                   description = "Minimum severity.";
-                  type = types.enum ["HINT" "INFO" "WARNING" "ERROR"];
+                  type = enum ["HINT" "INFO" "WARNING" "ERROR"];
                   default = "HINT";
                 };
 
                 max = mkOption {
                   description = "Maximum severity.";
-                  type = types.enum ["HINT" "INFO" "WARNING" "ERROR"];
+                  type = enum ["HINT" "INFO" "WARNING" "ERROR"];
                   default = "ERROR";
                 };
               };
@@ -290,19 +291,19 @@ in {
       enable = mkEnableOption "Git integration with icons and colors.";
 
       showOnDirs = mkOption {
-        type = types.bool;
+        type = bool;
         default = true;
         description = "Show git icons on parent directories.";
       };
 
       showOnOpenDirs = mkOption {
-        type = types.bool;
+        type = bool;
         default = true;
         description = "Show git icons on directories that are open.";
       };
 
       disableForDirs = mkOption {
-        type = with types; listOf str;
+        type = listOf str;
         default = [];
         description = ''
           Disable git integration when git top-level matches these paths.
@@ -311,7 +312,7 @@ in {
       };
 
       timeout = mkOption {
-        type = types.int;
+        type = int;
         default = 400;
         description = ''
           Kills the git process after some time if it takes too long.
@@ -323,18 +324,18 @@ in {
     modified = mkOption {
       description = "Indicate which file have unsaved modification.";
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           enable = mkEnableOption "Modified files with icons and color highlight.";
 
           showOnDirs = mkOption {
-            type = types.bool;
+            type = bool;
             description = "Show modified icons on parent directories.";
             default = true;
           };
 
           showOnOpenDirs = mkOption {
-            type = types.bool;
+            type = bool;
             description = "Show modified icons on directories that are open.";
             default = true;
           };
@@ -351,22 +352,22 @@ in {
         performance.
       '';
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           enable = mkOption {
             description = "Enable filesystem watchers.";
-            type = types.bool;
+            type = bool;
             default = true;
           };
 
           debounceDelay = mkOption {
             description = "Idle milliseconds between filesystem change and action.";
-            type = types.int;
+            type = int;
             default = 50;
           };
 
           ignoreDirs = mkOption {
-            type = with types; listOf str;
+            type = listOf str;
             default = [];
             description = ''
               List of vim regex for absolute directory paths that will not be watched.
@@ -385,22 +386,22 @@ in {
     view = mkOption {
       description = "Window / buffer setup.";
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           centralizeSelection = mkOption {
             description = "If true, reposition the view so that the current node is initially centralized when entering nvim-tree.";
-            type = types.bool;
+            type = bool;
             default = false;
           };
 
           cursorline = mkOption {
             description = "Enable cursorline in nvim-tree window.";
-            type = types.bool;
+            type = bool;
             default = true;
           };
 
           debounceDelay = mkOption {
-            type = types.int;
+            type = int;
             default = 15;
             description = ''
               Idle milliseconds before some reload / refresh operations.
@@ -416,7 +417,7 @@ in {
               A table (an attribute set in our case, see example) indicates that the view should be dynamically sized based on the
               longest line.
             '';
-            type = with types; oneOf [int attrs];
+            type = oneOf [int attrs];
             default = 30;
             example = literalExpression ''
               {
@@ -429,7 +430,7 @@ in {
 
           side = mkOption {
             description = "Side of the tree.";
-            type = types.enum ["left" "right"];
+            type = enum ["left" "right"];
             default = "left";
           };
 
@@ -438,13 +439,13 @@ in {
               Preserves window proportions when opening a file.
               If `false`, the height and width of windows other than nvim-tree will be equalized.
             '';
-            type = types.bool;
+            type = bool;
             default = false;
           };
 
           number = mkOption {
             description = "Print the line number in front of each line.";
-            type = types.bool;
+            type = bool;
             default = false;
           };
 
@@ -454,13 +455,13 @@ in {
               If the option `view.number` is also `true`, the number on the cursor line
               will be the line number instead of `0`.
             '';
-            type = types.bool;
+            type = bool;
             default = false;
           };
 
           signcolumn = mkOption {
             description = ''Show diagnostic sign column. Value can be `"yes"`, `"auto"` or`"no"`.'';
-            type = types.enum ["yes" "auto" "no"];
+            type = enum ["yes" "auto" "no"];
             default = "yes";
           };
 
@@ -468,23 +469,23 @@ in {
             description = "Configuration options for floating window.";
 
             default = {};
-            type = types.submodule {
+            type = submodule {
               options = {
                 enable = mkOption {
                   description = "If true, tree window will be floating.";
-                  type = types.bool;
+                  type = bool;
                   default = false;
                 };
 
                 quitOnFocusLoss = mkOption {
                   description = "Close the floating tree window when it loses focus.";
-                  type = types.bool;
+                  type = bool;
                   default = true;
                 };
 
                 openWinConfig = mkOption {
                   description = "Floating window config. See `:h nvim_open_win()` for more details.";
-                  type = types.attrs;
+                  type = attrs;
                   default = {
                     relative = "editor";
                     border = "rounded";
@@ -505,23 +506,23 @@ in {
       addTrailing = mkOption {
         default = false;
         description = "Appends a trailing slash to folder names.";
-        type = types.bool;
+        type = bool;
       };
 
       groupEmpty = mkOption {
         default = false;
         description = "Compact folders that only contain a single folder into one node in the file tree.";
-        type = types.bool;
+        type = bool;
       };
 
       fullName = mkOption {
         default = false;
         description = "Display node whose name length is wider than the width of nvim-tree window in floating window.";
-        type = types.bool;
+        type = bool;
       };
 
       highlightGit = mkOption {
-        type = types.bool;
+        type = bool;
         default = false;
         description = ''
           Enable file highlight for git attributes using `NvimTreeGit` highlight groups.
@@ -531,7 +532,7 @@ in {
       };
 
       highlightOpenedFiles = mkOption {
-        type = types.enum ["none" "icon" "name" "all"];
+        type = enum ["none" "icon" "name" "all"];
         default = "none";
         description = ''
           Highlight icons and/or names for bufloaded() files using the
@@ -540,7 +541,7 @@ in {
       };
 
       highlightModified = mkOption {
-        type = types.enum ["none" "icon" "name" "all"];
+        type = enum ["none" "icon" "name" "all"];
         default = "none";
         description = ''
           Highlight modified files in the tree using `NvimTreeNormal` highlight group.
@@ -549,7 +550,7 @@ in {
       };
 
       rootFolderLabel = mkOption {
-        type = with types; oneOf [str bool];
+        type = oneOf [str bool];
         default = false;
         example = ''"":~:s?$?/..?"'';
         description = ''
@@ -566,7 +567,7 @@ in {
       };
 
       indentWidth = mkOption {
-        type = with types; addCheck int (x: x >= 1);
+        type = addCheck int (x: x >= 1);
         default = 2;
         description = "Number of spaces for an each tree nesting level. Minimum 1.";
       };
@@ -574,17 +575,17 @@ in {
       indentMarkers = mkOption {
         description = "Configuration options for tree indent markers.";
         default = {};
-        type = types.submodule {
+        type = submodule {
           options = {
             enable = mkEnableOption "Display indent markers when folders are open.";
             inlineArrows = mkOption {
-              type = types.bool;
+              type = bool;
               default = true;
               description = "Display folder arrows in the same column as indent marker when using `renderer.icons.show.folder_arrow`";
             };
 
             icons = mkOption {
-              type = types.attrs;
+              type = attrs;
               description = "Individual elements of the indent markers";
               default = {
                 corner = "└";
@@ -599,13 +600,13 @@ in {
       };
 
       specialFiles = mkOption {
-        type = with types; listOf str;
+        type = listOf str;
         default = ["Cargo.toml" "README.md" "readme.md" "Makefile" "MAKEFILE" "flake.nix"]; # ;)
         description = "A list of filenames that gets highlighted with `NvimTreeSpecialFile";
       };
 
       symlinkDestination = mkOption {
-        type = types.bool;
+        type = bool;
         default = true;
         description = "Whether to show the destination of the symlink.";
       };
@@ -613,53 +614,53 @@ in {
       icons = mkOption {
         description = "Configuration options for icons.";
         default = {};
-        type = types.submodule {
+        type = submodule {
           options = {
             webdevColors = mkOption {
-              type = types.bool;
+              type = bool;
               description = " Use the webdev icon colors, otherwise `NvimTreeFileIcon`";
               default = true;
             };
 
             gitPlacement = mkOption {
-              type = types.enum ["before" "after" "signcolumn"];
+              type = enum ["before" "after" "signcolumn"];
               description = "Place where the git icons will be rendered. `signcolumn` requires `view.signcolumn` to be enabled.";
               default = "before";
             };
 
             modifiedPlacement = mkOption {
-              type = types.enum ["before" "after" "signcolumn"];
+              type = enum ["before" "after" "signcolumn"];
               description = "Place where the modified icons will be rendered. `signcolumn` requires `view.signcolumn` to be enabled.";
               default = "after";
             };
 
             padding = mkOption {
-              type = types.str;
+              type = str;
               description = "Inserted between icon and filename";
               default = " ";
             };
 
             symlinkArrow = mkOption {
-              type = types.str;
+              type = str;
               description = "Used as a separator between symlinks' source and target.";
               default = " ➛ ";
             };
 
             show = {
               file = mkOption {
-                type = types.bool;
+                type = bool;
                 description = "Show an icon before the file name. `nvim-web-devicons` will be used if available.";
                 default = true;
               };
 
               folder = mkOption {
-                type = types.bool;
+                type = bool;
                 description = "Show an icon before the folder name.";
                 default = true;
               };
 
               folderArrow = mkOption {
-                type = types.bool;
+                type = bool;
                 default = true;
                 description = ''
                   Show a small arrow before the folder node. Arrow will be a part of the
@@ -668,7 +669,7 @@ in {
               };
 
               git = mkOption {
-                type = types.bool;
+                type = bool;
                 default = false;
                 description = ''
                   Show a git status icon, see `renderer.icons.gitPlacement`
@@ -677,7 +678,7 @@ in {
               };
 
               modified = mkOption {
-                type = types.bool;
+                type = bool;
                 default = true;
                 description = ''
                   Show a modified icon, see `renderer.icons.modifiedPlacement`
@@ -692,29 +693,29 @@ in {
                 to appear in the signcolumn.
               '';
               default = {};
-              type = types.submodule {
+              type = submodule {
                 options = {
                   default = mkOption {
-                    type = types.str;
+                    type = str;
                     description = "Glyph for files. Will be overridden by `nvim-web-devicons` if available.";
                     default = "";
                   };
 
                   symlink = mkOption {
-                    type = types.str;
+                    type = str;
                     description = "Glyph for symlinks.";
                     default = "";
                   };
 
                   modified = mkOption {
-                    type = types.str;
+                    type = str;
                     description = "Icon to display for modified files.";
                     default = "";
                   };
 
                   # TODO: hardcode each attribute
                   folder = mkOption {
-                    type = types.attrs;
+                    type = attrs;
                     description = "Glyphs for directories. Recommended to use the defaults unless you know what you are doing.";
                     default = {
                       default = "";
@@ -729,7 +730,7 @@ in {
                   };
 
                   git = mkOption {
-                    type = types.attrs;
+                    type = attrs;
                     description = "Glyphs for git status.";
                     default = {
                       unstaged = "✗";
@@ -759,22 +760,22 @@ in {
         noBuffer = false;
         exclude = [];
       };
-      type = types.submodule {
+      type = submodule {
         options = {
           gitIgnored = mkOption {
-            type = types.bool;
+            type = bool;
             description = "Ignore files based on `.gitignore`. Requires git.enable` to be `true`";
             default = false;
           };
 
           dotfiles = mkOption {
-            type = types.bool;
+            type = bool;
             description = "Do not show dotfiles: files starting with a `.`";
             default = false;
           };
 
           gitClean = mkOption {
-            type = types.bool;
+            type = bool;
             default = false;
 
             description = ''
@@ -784,13 +785,13 @@ in {
           };
 
           noBuffer = mkOption {
-            type = types.bool;
+            type = bool;
             default = false;
             description = "Do not show files that have no `buflisted()` buffer.";
           };
 
           exclude = mkOption {
-            type = with types; listOf str;
+            type = listOf str;
             default = [];
             description = "List of directories or files to exclude from filtering: always show them.";
           };
@@ -804,10 +805,10 @@ in {
         cmd = "${pkgs.glib}/bin/gio trash";
       };
 
-      type = types.submodule {
+      type = submodule {
         options = {
           cmd = mkOption {
-            type = types.str;
+            type = str;
             description = "The command used to trash items";
           };
         };
@@ -817,10 +818,10 @@ in {
     actions = mkOption {
       description = "Configuration for various actions.";
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           useSystemClipboard = mkOption {
-            type = types.bool;
+            type = bool;
             default = true;
             description = ''
               A boolean value that toggle the use of system clipboard when copy/paste
@@ -833,16 +834,16 @@ in {
           changeDir = mkOption {
             description = "vim `change-directory` behaviour";
             default = {};
-            type = types.submodule {
+            type = submodule {
               options = {
                 enable = mkOption {
-                  type = types.bool;
+                  type = bool;
                   default = true;
                   description = "Change the working directory when changing directories in the tree.";
                 };
 
                 global = mkOption {
-                  type = types.bool;
+                  type = bool;
                   default = false;
                   description = ''
                     Use `:cd` instead of `:lcd` when changing directories.
@@ -851,7 +852,7 @@ in {
                 };
 
                 restrictAboveCwd = mkOption {
-                  type = types.bool;
+                  type = bool;
                   default = false;
                   description = ''
                     Restrict changing to a directory above the global current working directory.
@@ -865,10 +866,10 @@ in {
           expandAll = mkOption {
             description = "Configuration for expand_all behaviour.";
             default = {};
-            type = types.submodule {
+            type = submodule {
               options = {
                 maxFolderDiscovery = mkOption {
-                  type = types.int;
+                  type = int;
                   default = 300;
                   description = ''
                     Limit the number of folders being explored when expanding every folders.
@@ -876,7 +877,7 @@ in {
                   '';
                 };
                 exclude = mkOption {
-                  type = with types; listOf str;
+                  type = listOf str;
                   description = "A list of directories that should not be expanded automatically.";
                   default = [".git" "target" "build" "result"];
                 };
@@ -888,10 +889,10 @@ in {
           filePopup = mkOption {
             description = "Configuration for file_popup behaviour.";
             default = {};
-            type = types.submodule {
+            type = submodule {
               options = {
                 openWinConfig = mkOption {
-                  type = types.attrs;
+                  type = attrs;
                   default = {
                     col = 1;
                     row = 1;
@@ -909,22 +910,22 @@ in {
           openFile = mkOption {
             description = "Configuration options for opening a file from nvim-tree.";
             default = {};
-            type = types.submodule {
+            type = submodule {
               options = {
                 quitOnOpen = mkOption {
-                  type = types.bool;
+                  type = bool;
                   description = "Closes the explorer when opening a file.";
                   default = false;
                 };
 
                 eject = mkOption {
-                  type = types.bool;
+                  type = bool;
                   description = "Prevent new opened file from opening in the same window as the tree.";
                   default = false;
                 };
 
                 resizeWindow = mkOption {
-                  type = types.bool;
+                  type = bool;
                   default = false;
 
                   description = "Resizes the tree when opening a file. Previously `view.auto_resize`";
@@ -933,16 +934,16 @@ in {
                 windowPicker = mkOption {
                   description = "window_picker";
                   default = {};
-                  type = types.submodule {
+                  type = submodule {
                     options = {
                       enable = mkOption {
-                        type = types.bool;
+                        type = bool;
                         description = "Enable the window picker. If this feature is not enabled, files will open in window from which you last opened the tree.";
                         default = false;
                       };
 
                       picker = mkOption {
-                        type = types.str;
+                        type = str;
                         default = "default";
                         description = ''
                           Change the default window picker, can be a string `"default"` or a function.
@@ -959,20 +960,20 @@ in {
                       };
 
                       chars = mkOption {
-                        type = types.str;
+                        type = str;
                         description = "A string of chars used as identifiers by the window picker.";
                         default = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
                       };
 
                       exclude = {
                         filetype = mkOption {
-                          type = with types; listOf str;
+                          type = listOf str;
                           description = "A list of filetypes to exclude from the window picker.";
                           default = ["notify" "packer" "qf" "diff" "fugitive" "fugitiveblame"];
                         };
 
                         buftype = mkOption {
-                          type = with types; listOf str;
+                          type = listOf str;
                           description = "A list of buftypes to exclude from the window picker.";
                           default = ["nofile" "terminal" "help"];
                         };
@@ -986,7 +987,7 @@ in {
 
           removeFile = {
             closeWindow = mkOption {
-              type = types.bool;
+              type = bool;
               default = true;
               description = "Close any window displaying a file when removing the file from the tree";
             };
@@ -1004,16 +1005,16 @@ in {
         The filter can be cleared with the `F` key by default.
       '';
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           prefix = mkOption {
-            type = types.str;
+            type = str;
             description = "Prefix of the filter displayed in the buffer.";
             default = "[FILTER]: ";
           };
 
           alwaysShowFolders = mkOption {
-            type = types.bool;
+            type = bool;
             description = "Whether to filter folders or not.";
             default = true;
           };
@@ -1024,15 +1025,15 @@ in {
     tab = mkOption {
       description = "Configuration for tab behaviour.";
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           sync = mkOption {
             description = "Configuration for syncing nvim-tree across tabs.";
             default = {};
-            type = types.submodule {
+            type = submodule {
               options = {
                 open = mkOption {
-                  type = types.bool;
+                  type = bool;
                   default = false;
                   description = ''
                     Opens the tree automatically when switching tabpage or opening a new
@@ -1041,7 +1042,7 @@ in {
                 };
 
                 close = mkOption {
-                  type = types.bool;
+                  type = bool;
                   default = false;
                   description = ''
                     Closes the tree across all tabpages when the tree is closed.
@@ -1049,7 +1050,7 @@ in {
                 };
 
                 ignore = mkOption {
-                  type = with types; listOf str;
+                  type = listOf str;
                   default = [];
                   description = ''
                     List of filetypes or buffer names on new tab that will prevent
@@ -1066,16 +1067,16 @@ in {
     notify = mkOption {
       description = "Configuration for notifications.";
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           threshold = mkOption {
-            type = types.enum ["ERROR" "WARNING" "INFO" "DEBUG"];
+            type = enum ["ERROR" "WARNING" "INFO" "DEBUG"];
             description = "Specify minimum notification level, uses the values from `vim.log.levels`";
             default = "INFO";
           };
 
           absolutePath = mkOption {
-            type = types.bool;
+            type = bool;
             description = "Whether to use absolute paths or item names in fs action notifications.";
             default = true;
           };
@@ -1086,17 +1087,17 @@ in {
     ui = mkOption {
       description = "General UI configuration.";
       default = {};
-      type = types.submodule {
+      type = submodule {
         options = {
           confirm = {
             remove = mkOption {
-              type = types.bool;
+              type = bool;
               description = "Prompt before removing.";
               default = true;
             };
 
             trash = mkOption {
-              type = types.bool;
+              type = bool;
               description = "Prompt before trash.";
               default = true;
             };
@@ -1109,7 +1110,7 @@ in {
     openOnSetup = mkOption {
       default = true;
       description = "Open when vim is started on a directory";
-      type = types.bool;
+      type = bool;
     };
   };
 }

--- a/modules/languages/bash/bash.nix
+++ b/modules/languages/bash/bash.nix
@@ -9,6 +9,7 @@
   inherit (lib.lists) isList;
   inherit (lib.types) enum either package listOf str bool;
   inherit (lib.nvim.lua) expToLua;
+  inherit (lib.nvim.types) diagnostics mkGrammarOption;
 
   cfg = config.vim.languages.bash;
 
@@ -45,8 +46,8 @@
     };
   };
 
-  defaultDiagnostics = ["shellcheck"];
-  diagnostics = {
+  defaultDiagnosticsProvider = ["shellcheck"];
+  diagnosticsProviders = {
     shellcheck = {
       package = pkgs.shellcheck;
       nullConfig = pkg: ''
@@ -65,7 +66,7 @@ in {
 
     treesitter = {
       enable = mkEnableOption "Bash treesitter" // {default = config.vim.languages.enableTreesitter;};
-      package = lib.nvim.types.mkGrammarOption pkgs "bash";
+      package = mkGrammarOption pkgs "bash";
     };
 
     lsp = {
@@ -106,10 +107,10 @@ in {
 
     extraDiagnostics = {
       enable = mkEnableOption "extra Bash diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
-      types = lib.nvim.types.diagnostics {
+      types = diagnostics {
         langDesc = "Bash";
-        inherit diagnostics;
-        inherit defaultDiagnostics;
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
       };
     };
   };

--- a/modules/languages/bash/config.nix
+++ b/modules/languages/bash/config.nix
@@ -7,9 +7,10 @@
   inherit (lib.lists) isList;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.nvim.lua) expToLua;
+  inherit (lib.nvim.languages) diagnosticsToLua;
 
   cfg = config.vim.languages.bash;
-  diagnostics = {
+  diagnosticsProviders = {
     shellcheck = {
       package = pkgs.shellcheck;
       nullConfig = pkg: ''
@@ -72,10 +73,10 @@ in {
 
     (mkIf cfg.extraDiagnostics.enable {
       vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources = lib.nvim.languages.diagnosticsToLua {
+      vim.lsp.null-ls.sources = diagnosticsToLua {
         lang = "bash";
         config = cfg.extraDiagnostics.types;
-        inherit diagnostics;
+        inherit diagnosticsProviders;
       };
     })
   ]);

--- a/modules/languages/clang.nix
+++ b/modules/languages/clang.nix
@@ -6,15 +6,17 @@
 }: let
   inherit (builtins) attrNames;
   inherit (lib.lists) isList;
-  inherit (lib) nvim;
   inherit (lib.strings) optionalString;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.types) bool enum package either listOf str nullOr;
   inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.lua) expToLua;
+  inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   packageToCmd = package: defaultCmd:
     if isList cfg.lsp.package
-    then nvim.lua.expToLua cfg.lsp.package
+    then expToLua cfg.lsp.package
     else ''{ "${cfg.lsp.package}/bin/${defaultCmd}" }'';
 
   cfg = config.vim.languages.clang;
@@ -91,8 +93,8 @@ in {
 
     treesitter = {
       enable = mkEnableOption "C/C++ treesitter" // {default = config.vim.languages.enableTreesitter;};
-      cPackage = nvim.types.mkGrammarOption pkgs "c";
-      cppPackage = nvim.types.mkGrammarOption pkgs "cpp";
+      cPackage = mkGrammarOption pkgs "c";
+      cppPackage = mkGrammarOption pkgs "cpp";
     };
 
     lsp = {
@@ -139,7 +141,7 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     (mkIf cfg.cHeader {
-      vim.configRC.c-header = nvim.dag.entryAnywhere "let g:c_syntax_for_h = 1";
+      vim.configRC.c-header = entryAnywhere "let g:c_syntax_for_h = 1";
     })
 
     (mkIf cfg.treesitter.enable {

--- a/modules/languages/sql.nix
+++ b/modules/languages/sql.nix
@@ -10,6 +10,8 @@
   inherit (lib.lists) isList;
   inherit (lib.types) enum either listOf package str;
   inherit (lib.nvim.lua) expToLua;
+  inherit (lib.nvim.languages) diagnosticsToLua;
+  inherit (lib.nvim.types) diagnostics;
 
   cfg = config.vim.languages.sql;
   sqlfluffDefault = pkgs.sqlfluff;
@@ -51,8 +53,8 @@
     };
   };
 
-  defaultDiagnostics = ["sqlfluff"];
-  diagnostics = {
+  defaultDiagnosticsProvider = ["sqlfluff"];
+  diagnosticsProviders = {
     sqlfluff = {
       package = sqlfluffDefault;
       nullConfig = pkg: ''
@@ -122,10 +124,10 @@ in {
     extraDiagnostics = {
       enable = mkEnableOption "extra SQL diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
 
-      types = lib.nvim.types.diagnostics {
+      types = diagnostics {
         langDesc = "SQL";
-        inherit diagnostics;
-        inherit defaultDiagnostics;
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
       };
     };
   };
@@ -154,10 +156,10 @@ in {
 
     (mkIf cfg.extraDiagnostics.enable {
       vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources = lib.nvim.languages.diagnosticsToLua {
+      vim.lsp.null-ls.sources = diagnosticsToLua {
         lang = "sql";
         config = cfg.extraDiagnostics.types;
-        inherit diagnostics;
+        inherit diagnosticsProviders;
       };
     })
   ]);

--- a/modules/languages/tidal/config.nix
+++ b/modules/languages/tidal/config.nix
@@ -4,7 +4,7 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf;
+  inherit (lib.modules) mkIf;
 
   cfg = config.vim.tidal;
 in {

--- a/modules/languages/tidal/tidal.nix
+++ b/modules/languages/tidal/tidal.nix
@@ -3,20 +3,21 @@
   lib,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption types;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) int bool;
 in {
   options.vim.tidal = {
     enable = mkEnableOption "tidalcycles tools and plugins";
 
     flash = mkOption {
       description = ''When sending a paragraph or a single line, vim-tidal will "flash" the selection for some milliseconds'';
-      type = types.int;
+      type = int;
       default = 150;
     };
 
     openSC = mkOption {
       description = "Automatically run the supercollider CLI, sclang, alongside the Tidal GHCI terminal.";
-      type = types.bool;
+      type = bool;
       default = true;
     };
   };

--- a/modules/lsp/config.nix
+++ b/modules/lsp/config.nix
@@ -4,7 +4,11 @@
   pkgs,
   ...
 }: let
-  inherit (lib) addDescriptionsToMappings mkIf optional boolToString optionalString;
+  inherit (lib.modules) mkIf;
+  inherit (lib.lists) optional;
+  inherit (lib.strings) optionalString;
+  inherit (lib.trivial) boolToString;
+  inherit (lib.nvim.binds) addDescriptionsToMappings;
 
   cfg = config.vim.lsp;
   usingNvimCmp = config.vim.autocomplete.enable && config.vim.autocomplete.type == "nvim-cmp";

--- a/modules/lsp/null-ls/config.nix
+++ b/modules/lsp/null-ls/config.nix
@@ -3,7 +3,9 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf mkMerge nvim mapAttrs;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.attrsets) mapAttrs;
+  inherit (lib.nvim.dag) entryAnywhere entryAfter entryBetween;
 
   cfg = config.vim.lsp;
 in {
@@ -13,14 +15,14 @@ in {
         lsp.enable = true;
         startPlugins = ["none-ls"];
 
-        luaConfigRC.null_ls-setup = nvim.dag.entryAnywhere ''
+        luaConfigRC.null_ls-setup = entryAnywhere ''
           local null_ls = require("null-ls")
           local null_helpers = require("null-ls.helpers")
           local null_methods = require("null-ls.methods")
           local ls_sources = {}
         '';
 
-        luaConfigRC.null_ls = nvim.dag.entryAfter ["null_ls-setup" "lsp-setup"] ''
+        luaConfigRC.null_ls = entryAfter ["null_ls-setup" "lsp-setup"] ''
           require('null-ls').setup({
             debug = false,
             diagnostics_format = "[#{m}] #{s} (#{c})",
@@ -33,7 +35,7 @@ in {
       };
     }
     {
-      vim.luaConfigRC = mapAttrs (_: v: (nvim.dag.entryBetween ["null_ls"] ["null_ls-setup"] v)) cfg.null-ls.sources;
+      vim.luaConfigRC = mapAttrs (_: v: (entryBetween ["null_ls"] ["null_ls-setup"] v)) cfg.null-ls.sources;
     }
   ]);
 }

--- a/modules/rich-presence/neocord/config.nix
+++ b/modules/rich-presence/neocord/config.nix
@@ -3,17 +3,19 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf nvim boolToString;
-  inherit (lib.nvim.lua) listToLuaTable;
-  inherit (lib.strings) escapeNixString;
   inherit (builtins) toString;
+  inherit (lib.modules) mkIf;
+  inherit (lib.trivial) boolToString;
+  inherit (lib.strings) escapeNixString;
+  inherit (lib.nvim.lua) listToLuaTable;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.presence.neocord;
 in {
   config = mkIf cfg.enable {
     vim.startPlugins = ["neocord"];
 
-    vim.luaConfigRC.neocord = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.neocord = entryAnywhere ''
       -- Description of each option can be found in https://github.com/IogaMaster/neocord#lua
       require("neocord").setup({
           -- General options

--- a/modules/rich-presence/neocord/neocord.nix
+++ b/modules/rich-presence/neocord/neocord.nix
@@ -1,5 +1,7 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption mkOption types literalExpression mkRemovedOptionModule;
+  inherit (lib.modules) mkRemovedOptionModule;
+  inherit (lib.options) mkEnableOption mkOption literalExpression;
+  inherit (lib.types) bool int str enum nullOr listOf;
 in {
   imports = [
     (mkRemovedOptionModule ["vim" "presence" "presence-nvim"] ''
@@ -14,7 +16,7 @@ in {
     enable = mkEnableOption "neocord plugin for discord rich presence";
 
     logo = mkOption {
-      type = types.str; # TODO: can the default be documented better, maybe with an enum?
+      type = str; # TODO: can the default be documented better, maybe with an enum?
       default = "auto";
       description = ''
         Logo to be displayed on the RPC item
@@ -24,55 +26,55 @@ in {
     };
 
     logo_tooltip = mkOption {
-      type = types.str;
+      type = str;
       default = "The One True Text Editor";
       description = "Text displayed when hovering over the Neovim image";
     };
 
     main_image = mkOption {
-      type = types.enum ["language" "logo"];
+      type = enum ["language" "logo"];
       default = "language";
       description = "Main image to be displayed";
     };
 
     client_id = mkOption {
-      type = types.str;
+      type = str;
       default = "1157438221865717891";
       description = "Client ID of the application";
     };
 
     log_level = mkOption {
-      type = with types; nullOr (enum ["debug" "info" "warn" "error"]);
+      type = nullOr (enum ["debug" "info" "warn" "error"]);
       default = null;
       description = "Log level to be used by the plugin";
     };
 
     debounce_timeout = mkOption {
-      type = types.int;
+      type = int;
       default = 10;
       description = "Number of seconds to debounce events";
     };
 
     auto_update = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Automatically update the presence";
     };
 
     enable_line_number = mkOption {
-      type = types.bool;
+      type = bool;
       default = false;
       description = "Show line number on the RPC item";
     };
 
     show_time = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Show time on the RPC item";
     };
 
     blacklist = mkOption {
-      type = with types; listOf str;
+      type = listOf str;
       default = [];
       example = literalExpression ''["Alpha"]'';
       description = "List of filetypes to ignore";
@@ -80,49 +82,49 @@ in {
 
     rich_presence = {
       editing_text = mkOption {
-        type = types.str;
+        type = str;
         default = "Editing %s";
         description = "Text displayed when editing a file";
       };
 
       file_explorer_text = mkOption {
-        type = types.str;
+        type = str;
         default = "Browsing %s";
         description = "Text displayed when browsing files";
       };
 
       git_commit_text = mkOption {
-        type = types.str;
+        type = str;
         default = "Committing changes";
         description = "Text displayed when committing changes";
       };
 
       plugin_manager_text = mkOption {
-        type = types.str;
+        type = str;
         default = "Managing plugins";
         description = "Text displayed when managing plugins";
       };
 
       reading_text = mkOption {
-        type = types.str;
+        type = str;
         default = "Reading %s";
         description = "Text displayed when reading a file";
       };
 
       workspace_text = mkOption {
-        type = types.str;
+        type = str;
         default = "Working on %s";
         description = "Text displayed when working on a project";
       };
 
       line_number_text = mkOption {
-        type = types.str;
+        type = str;
         default = "Line %s out of %s";
         description = "Text displayed when showing line number";
       };
 
       terminal_text = mkOption {
-        type = types.str;
+        type = str;
         default = "Working on the terminal";
         description = "Text displayed when working on the terminal";
       };

--- a/modules/ui/borders/borders.nix
+++ b/modules/ui/borders/borders.nix
@@ -4,6 +4,7 @@
   ...
 }: let
   inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.lists) optionals;
   inherit (lib.types) enum;
 
   cfg = config.vim.ui.borders;
@@ -27,7 +28,7 @@ in {
         enable = mkEnableOption "borders for the ${name} plugin" // {default = cfg.enable;};
 
         style = mkOption {
-          type = enum (defaultStyles ++ lib.optionals (name != "which-key") ["shadow"]);
+          type = enum (defaultStyles ++ optionals (name != "which-key") ["shadow"]);
           default = cfg.globalStyle;
           description = "The border style to use for the ${name} plugin";
         };

--- a/modules/ui/noice/noice.nix
+++ b/modules/ui/noice/noice.nix
@@ -1,5 +1,5 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption;
+  inherit (lib.options) mkEnableOption;
 in {
   options.vim.ui.noice = {
     enable = mkEnableOption "UI modification library [noice.nvim]";

--- a/modules/utility/binds/cheatsheet/cheatsheet.nix
+++ b/modules/utility/binds/cheatsheet/cheatsheet.nix
@@ -3,7 +3,7 @@
   lib,
   ...
 }: let
-  inherit (lib) mkEnableOption;
+  inherit (lib.options) mkEnableOption;
 in {
   options.vim.binds.cheatsheet = {
     enable = mkEnableOption "cheatsheet-nvim: searchable cheatsheet for nvim using telescope";

--- a/modules/utility/binds/cheatsheet/config.nix
+++ b/modules/utility/binds/cheatsheet/config.nix
@@ -3,14 +3,15 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf nvim;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.binds.cheatsheet;
 in {
   config = mkIf (cfg.enable) {
     vim.startPlugins = ["cheatsheet-nvim"];
 
-    vim.luaConfigRC.cheaetsheet-nvim = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.cheaetsheet-nvim = entryAnywhere ''
       require('cheatsheet').setup({})
     '';
   };

--- a/modules/utility/ccc/ccc.nix
+++ b/modules/utility/ccc/ccc.nix
@@ -1,5 +1,6 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption mkMappingOption;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.binds) mkMappingOption;
 in {
   options.vim.utility.ccc = {
     enable = mkEnableOption "ccc color picker for neovim";

--- a/modules/utility/ccc/config.nix
+++ b/modules/utility/ccc/config.nix
@@ -3,20 +3,17 @@
   lib,
   ...
 }: let
-  inherit (lib) addDescriptionsToMappings mkIf nvim;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.utility.ccc;
-  self = import ./ccc.nix {inherit lib;};
-
-  mappingDefinitions = self.options.vim.utility.ccc.mappings;
-  mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
   config = mkIf (cfg.enable) {
     vim.startPlugins = [
       "ccc"
     ];
 
-    vim.luaConfigRC.ccc = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.ccc = entryAnywhere ''
       local ccc = require("ccc")
       ccc.setup {
       	highlighter = {

--- a/modules/utility/diffview/config.nix
+++ b/modules/utility/diffview/config.nix
@@ -3,7 +3,7 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf nvim;
+  inherit (lib.modules) mkIf;
 
   cfg = config.vim.utility.diffview-nvim;
 in {
@@ -12,9 +12,5 @@ in {
       "diffview-nvim"
       "plenary-nvim"
     ];
-
-    vim.luaConfigRC.diffview-nvim =
-      nvim.dag.entryAnywhere ''
-      '';
   };
 }

--- a/modules/utility/diffview/diffview.nix
+++ b/modules/utility/diffview/diffview.nix
@@ -1,5 +1,5 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption;
+  inherit (lib.options) mkEnableOption;
 in {
   options.vim.utility.diffview-nvim = {
     enable = mkEnableOption "diffview-nvim: cycle through diffs for all modified files for any git rev";

--- a/modules/utility/gestures/gesture-nvim/config.nix
+++ b/modules/utility/gestures/gesture-nvim/config.nix
@@ -3,7 +3,9 @@
   lib,
   ...
 }: let
-  inherit (lib) addDescriptionsToMappings mkIf mkMerge mkSetLuaBinding nvim;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetLuaBinding;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.gestures.gesture-nvim;
 
@@ -23,7 +25,7 @@ in {
       })
     ];
 
-    vim.luaConfigRC.gesture-nvim = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.gesture-nvim = entryAnywhere ''
       vim.opt.mouse = "a"
 
       local gesture = require("gesture")

--- a/modules/utility/gestures/gesture-nvim/gesture-nvim.nix
+++ b/modules/utility/gestures/gesture-nvim/gesture-nvim.nix
@@ -1,5 +1,6 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption mkMappingOption;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.binds) mkMappingOption;
 in {
   options.vim.gestures.gesture-nvim = {
     enable = mkEnableOption "gesture-nvim: mouse gestures";

--- a/modules/utility/icon-picker/config.nix
+++ b/modules/utility/icon-picker/config.nix
@@ -3,7 +3,8 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf nvim;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.utility.icon-picker;
 in {
@@ -13,7 +14,7 @@ in {
       "dressing-nvim"
     ];
 
-    vim.luaConfigRC.icon-picker = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.icon-picker = entryAnywhere ''
       require("icon-picker").setup({
         disable_legacy_commands = true
       })

--- a/modules/utility/icon-picker/icon-picker.nix
+++ b/modules/utility/icon-picker/icon-picker.nix
@@ -1,5 +1,5 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption;
+  inherit (lib.options) mkEnableOption;
 in {
   options.vim.utility.icon-picker = {
     enable = mkEnableOption "nerdfonts icon picker for nvim";

--- a/modules/utility/motion/hop/config.nix
+++ b/modules/utility/motion/hop/config.nix
@@ -3,7 +3,9 @@
   lib,
   ...
 }: let
-  inherit (lib) addDescriptionsToMappings mkIf mkSetBinding nvim;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetBinding;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.utility.motion.hop;
 
@@ -17,7 +19,7 @@ in {
 
     vim.maps.normal = mkSetBinding mappings.hop "<cmd> HopPattern<CR>";
 
-    vim.luaConfigRC.hop-nvim = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.hop-nvim = entryAnywhere ''
       require('hop').setup()
     '';
   };

--- a/modules/utility/motion/hop/hop.nix
+++ b/modules/utility/motion/hop/hop.nix
@@ -1,5 +1,6 @@
 {lib, ...}: let
-  inherit (lib) mkMappingOption mkEnableOption;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.binds) mkMappingOption;
 in {
   options.vim.utility.motion.hop = {
     mappings = {

--- a/modules/utility/motion/leap/config.nix
+++ b/modules/utility/motion/leap/config.nix
@@ -3,7 +3,9 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf mkMerge mkBinding nvim;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.binds) mkBinding;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.utility.motion.leap;
 in {
@@ -35,7 +37,7 @@ in {
       (mkBinding cfg.mappings.leapFromWindow "<Plug>(leap-from-window)" "Leap from window")
     ];
 
-    vim.luaConfigRC.leap-nvim = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.leap-nvim = entryAnywhere ''
       require('leap').opts = {
         max_phase_one_targets = nil,
         highlight_unlabeled_phase_one_targets = false,

--- a/modules/utility/motion/leap/leap.nix
+++ b/modules/utility/motion/leap/leap.nix
@@ -1,32 +1,33 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption mkOption types;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) nullOr str;
 in {
   options.vim.utility.motion.leap = {
     enable = mkEnableOption "leap.nvim plugin (easy motion)";
 
     mappings = {
       leapForwardTo = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         description = "Leap forward to";
         default = "s";
       };
       leapBackwardTo = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         description = "Leap backward to";
         default = "S";
       };
       leapForwardTill = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         description = "Leap forward till";
         default = "x";
       };
       leapBackwardTill = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         description = "Leap backward till";
         default = "X";
       };
       leapFromWindow = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         description = "Leap from window";
         default = "gs";
       };

--- a/modules/utility/preview/glow/config.nix
+++ b/modules/utility/preview/glow/config.nix
@@ -4,7 +4,11 @@
   lib,
   ...
 }: let
-  inherit (lib) nvim mkIf mkMerge mkBinding pushDownDefault;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.binds) mkBinding;
+  inherit (lib.nvim.dag) entryAnywhere;
+  # TODO: move this to its own module
+  inherit (lib) pushDownDefault;
 
   cfg = config.vim.utility.preview.glow;
   self = import ./glow.nix {
@@ -23,7 +27,7 @@ in {
       "<leader>pm" = "+Preview Markdown";
     };
 
-    vim.luaConfigRC.glow = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.glow = entryAnywhere ''
       require('glow').setup({
         glow_path = "${pkgs.glow}/bin/glow"
       });

--- a/modules/utility/preview/glow/glow.nix
+++ b/modules/utility/preview/glow/glow.nix
@@ -1,5 +1,7 @@
 {lib, ...}: let
-  inherit (lib) mkEnableOption mkMappingOption mkRenamedOptionModule;
+  inherit (lib.modules) mkRenamedOptionModule;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.binds) mkMappingOption;
 in {
   imports = [
     (mkRenamedOptionModule ["vim" "languages" "markdown" "glow" "enable"] ["vim" "utility" "preview" "glow" "enable"])

--- a/modules/utility/preview/markdown-preview/config.nix
+++ b/modules/utility/preview/markdown-preview/config.nix
@@ -4,15 +4,17 @@
   lib,
   ...
 }: let
-  inherit (lib) nvim mkIf concatMapStringsSep optionalString stringLength;
-  inherit (nvim.vim) mkVimBool;
+  inherit (lib.strings) optionalString stringLength concatMapStringsSep;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.vim) mkVimBool;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.utility.preview.markdownPreview;
 in {
   config = mkIf cfg.enable {
     vim.startPlugins = [pkgs.vimPlugins.markdown-preview-nvim];
 
-    vim.configRC.markdown-preview = nvim.dag.entryAnywhere ''
+    vim.configRC.markdown-preview = entryAnywhere ''
       let g:mkdp_auto_start = ${mkVimBool cfg.autoStart}
       let g:mkdp_auto_close = ${mkVimBool cfg.autoClose}
       let g:mkdp_refresh_slow = ${mkVimBool cfg.lazyRefresh}

--- a/modules/utility/preview/markdown-preview/markdown-preview.nix
+++ b/modules/utility/preview/markdown-preview/markdown-preview.nix
@@ -1,54 +1,55 @@
 {lib, ...}: let
-  inherit (lib) types mkEnableOption mkOption;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) bool str listOf;
 in {
   options.vim.utility.preview = {
     markdownPreview = {
       enable = mkEnableOption "Markdown preview in neovim with markdown-preview.nvim";
 
       autoStart = mkOption {
-        type = types.bool;
+        type = bool;
         default = false;
         description = "Automatically open the preview window after entering a Markdown buffer";
       };
 
       autoClose = mkOption {
-        type = types.bool;
+        type = bool;
         default = true;
         description = "Automatically close the preview window after leaving a Markdown buffer";
       };
 
       lazyRefresh = mkOption {
-        type = types.bool;
+        type = bool;
         default = false;
         description = "Only update preview when saving or leaving insert mode";
       };
 
       filetypes = mkOption {
-        type = with types; listOf str;
+        type = listOf str;
         default = ["markdown"];
         description = "Allowed filetypes";
       };
 
       alwaysAllowPreview = mkOption {
-        type = types.bool;
+        type = bool;
         default = false;
         description = "Allow preview on all filetypes";
       };
 
       broadcastServer = mkOption {
-        type = types.bool;
+        type = bool;
         default = false;
         description = "Allow for outside and network wide connections";
       };
 
       customIP = mkOption {
-        type = types.str;
+        type = str;
         default = "";
         description = "IP-address to use";
       };
 
       customPort = mkOption {
-        type = types.str;
+        type = str;
         default = "";
         description = "Port to use";
       };

--- a/modules/utility/surround/config.nix
+++ b/modules/utility/surround/config.nix
@@ -3,7 +3,9 @@
   lib,
   ...
 }: let
-  inherit (lib) addDescriptionsToMappings mkIf mkMerge mkSetBinding nvim;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetBinding;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.utility.surround;
   self = import ./surround.nix {inherit lib config;};
@@ -16,7 +18,7 @@ in {
         "nvim-surround"
       ];
 
-      luaConfigRC.surround = nvim.dag.entryAnywhere ''
+      luaConfigRC.surround = entryAnywhere ''
         require('nvim-surround').setup()
       '';
 

--- a/modules/utility/surround/surround.nix
+++ b/modules/utility/surround/surround.nix
@@ -3,67 +3,69 @@
   config,
   ...
 }: let
-  inherit (lib) mkOption types mkIf mkDefault;
+  inherit (lib.modules) mkIf mkDefault;
+  inherit (lib.options) mkOption;
+  inherit (lib.types) bool nullOr str;
 in {
   options.vim.utility.surround = {
     enable = mkOption {
-      type = types.bool;
+      type = bool;
       default = false;
       description = "nvim-surround: add/change/delete surrounding delimiter pairs with ease. Note that the default mappings deviate from upstreeam to avoid conflicts with nvim-leap.";
     };
     useVendoredKeybindings = mkOption {
-      type = types.bool;
+      type = bool;
       default = true;
       description = "Use alternative set of keybindings that avoids conflicts with other popular plugins, e.g. nvim-leap";
     };
     mappings = {
       insert = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "<C-g>z";
         description = "Add surround character around the cursor";
       };
       insertLine = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "<C-g>Z";
         description = "Add surround character around the cursor on new lines";
       };
       normal = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "gz";
         description = "Surround motion with character";
       };
       normalCur = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "gZ";
         description = "Surround motion with character on new lines";
       };
       normalLine = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "gzz";
         description = "Surround line with character";
       };
       normalCurLine = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "gZZ";
         description = "Surround line with character on new lines";
       };
       visual = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "gz";
         description = "Surround selection with character";
       };
       visualLine = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "gZ";
         description = "Surround selection with character on new lines";
       };
       delete = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "gzd";
         description = "Delete surrounding character";
       };
       change = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         default = "gzr";
         description = "Change surrounding character";
       };

--- a/modules/utility/telescope/config.nix
+++ b/modules/utility/telescope/config.nix
@@ -4,7 +4,11 @@
   lib,
   ...
 }: let
-  inherit (lib) addDescriptionsToMappings mkIf mkMerge mkSetBinding nvim pushDownDefault;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetBinding;
+  inherit (lib.nvim.dag) entryAnywhere;
+  # TODO: move this to its own module
+  inherit (lib) pushDownDefault;
 
   cfg = config.vim.telescope;
   self = import ./telescope.nix {inherit lib;};
@@ -60,7 +64,7 @@ in {
       "<leader>fvc" = "Commits";
     };
 
-    vim.luaConfigRC.telescope = nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.telescope = entryAnywhere ''
       local telescope = require('telescope')
       telescope.setup {
         defaults = {

--- a/modules/utility/telescope/telescope.nix
+++ b/modules/utility/telescope/telescope.nix
@@ -1,5 +1,6 @@
 {lib, ...}: let
-  inherit (lib) mkMappingOption mkEnableOption;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.binds) mkMappingOption;
 in {
   options.vim.telescope = {
     mappings = {

--- a/modules/utility/wakatime/config.nix
+++ b/modules/utility/wakatime/config.nix
@@ -4,7 +4,8 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkIf nvim;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.utility.vim-wakatime;
 in {
@@ -13,7 +14,7 @@ in {
       pkgs.vimPlugins.vim-wakatime
     ];
 
-    vim.configRC.vim-wakatime = nvim.dag.entryAnywhere ''
+    vim.configRC.vim-wakatime = entryAnywhere ''
       ${
         if cfg.cli-package == null
         then ""

--- a/modules/utility/wakatime/vim-wakatime.nix
+++ b/modules/utility/wakatime/vim-wakatime.nix
@@ -3,13 +3,14 @@
   pkgs,
   ...
 }: let
-  inherit (lib) mkEnableOption mkOption types;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) nullOr package;
 in {
   options.vim.utility.vim-wakatime = {
     enable = mkEnableOption "vim-wakatime: live code statistics";
 
     cli-package = mkOption {
-      type = with types; nullOr package;
+      type = nullOr package;
       default = pkgs.wakatime;
       description = "The package that should be used for wakatime-cli. Set as null to use the default path in `$XDG_DATA_HOME`";
     };

--- a/modules/visuals/config.nix
+++ b/modules/visuals/config.nix
@@ -3,14 +3,18 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf mkMerge nvim optionalString boolToString mkBinding;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.strings) optionalString;
+  inherit (lib.trivial) boolToString;
+  inherit (lib.nvim.binds) mkBinding;
+  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.visuals;
 in {
   config = mkIf cfg.enable (mkMerge [
     (mkIf cfg.indentBlankline.enable {
       vim.startPlugins = ["indent-blankline"];
-      vim.luaConfigRC.indent-blankline = nvim.dag.entryAnywhere ''
+      vim.luaConfigRC.indent-blankline = entryAnywhere ''
         -- highlight error: https://github.com/lukas-reineke/indent-blankline.nvim/issues/59
         -- vim.wo.colorcolumn = "99999"
         vim.opt.list = true
@@ -42,7 +46,7 @@ in {
 
     (mkIf cfg.cursorline.enable {
       vim.startPlugins = ["nvim-cursorline"];
-      vim.luaConfigRC.cursorline = nvim.dag.entryAnywhere ''
+      vim.luaConfigRC.cursorline = entryAnywhere ''
         require('nvim-cursorline').setup {
           cursorline = {
             timeout = ${toString cfg.cursorline.lineTimeout},
@@ -58,7 +62,7 @@ in {
 
     (mkIf cfg.scrollBar.enable {
       vim.startPlugins = ["scrollbar-nvim"];
-      vim.luaConfigRC.scrollBar = nvim.dag.entryAnywhere ''
+      vim.luaConfigRC.scrollBar = entryAnywhere ''
         require('scrollbar').setup{
             excluded_filetypes = {
               'prompt',
@@ -77,7 +81,7 @@ in {
 
     (mkIf cfg.smoothScroll.enable {
       vim.startPlugins = ["cinnamon-nvim"];
-      vim.luaConfigRC.smoothScroll = nvim.dag.entryAnywhere ''
+      vim.luaConfigRC.smoothScroll = entryAnywhere ''
         require('cinnamon').setup()
       '';
     })
@@ -87,7 +91,7 @@ in {
 
       vim.maps.normal = mkBinding cfg.cellularAutomaton.mappings.makeItRain "<cmd>CellularAutomaton make_it_rain<CR>" "Make it rain";
 
-      vim.luaConfigRC.cellularAUtomaton = nvim.dag.entryAnywhere ''
+      vim.luaConfigRC.cellularAUtomaton = entryAnywhere ''
         local config = {
               fps = 50,
               name = 'slide',
@@ -115,7 +119,7 @@ in {
 
     (mkIf cfg.highlight-undo.enable {
       vim.startPlugins = ["highlight-undo"];
-      vim.luaConfigRC.highlight-undo = nvim.dag.entryAnywhere ''
+      vim.luaConfigRC.highlight-undo = entryAnywhere ''
         require('highlight-undo').setup({
           duration = ${toString cfg.highlight-undo.duration},
           highlight_for_count = ${boolToString cfg.highlight-undo.highlightForCount},

--- a/modules/visuals/fidget/config.nix
+++ b/modules/visuals/fidget/config.nix
@@ -3,14 +3,17 @@
   lib,
   ...
 }: let
-  inherit (lib) mkIf nvim;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.dag) entryAnywhere;
+
   cfg = config.vim.visuals.fidget-nvim;
 in {
   config = mkIf cfg.enable {
     vim.startPlugins = ["fidget-nvim"];
 
-    vim.luaConfigRC.fidget-nvim = nvim.dag.entryAnywhere ''
-      require'fidget'.setup(${nvim.lua.toLuaObject cfg.setupOpts})
+    vim.luaConfigRC.fidget-nvim = entryAnywhere ''
+      require'fidget'.setup(${toLuaObject cfg.setupOpts})
     '';
   };
 }

--- a/modules/visuals/fidget/fidget.nix
+++ b/modules/visuals/fidget/fidget.nix
@@ -3,7 +3,13 @@
   lib,
   ...
 }: let
-  inherit (lib) mkRemovedOptionModule mkEnableOption mkOption mapAttrs toUpper nvim types mkRenamedOptionModule;
+  inherit (lib.modules) mkRemovedOptionModule mkRenamedOptionModule;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.attrsets) mapAttrs;
+  inherit (lib.strings) toUpper;
+  inherit (lib.types) int float bool str enum listOf attrsOf;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+
   rawLua = lua: {__raw = lua;};
 in {
   imports = [
@@ -15,31 +21,31 @@ in {
   options.vim.visuals.fidget-nvim = {
     enable = mkEnableOption "nvim LSP UI element [fidget-nvim]";
 
-    setupOpts = nvim.types.mkPluginSetupOption "Fidget" {
+    setupOpts = mkPluginSetupOption "Fidget" {
       progress = {
         poll_rate = mkOption {
           description = "How frequently to poll for LSP progress messages";
-          type = types.int;
+          type = int;
           default = 0;
         };
         suppress_on_insert = mkOption {
           description = "Suppress new messages when in insert mode";
-          type = types.bool;
+          type = bool;
           default = false;
         };
         ignore_done_already = mkOption {
           description = "Ignore new tasks that are already done";
-          type = types.bool;
+          type = bool;
           default = false;
         };
         ignore_empty_message = mkOption {
           description = "Ignore new tasks with empty messages";
-          type = types.bool;
+          type = bool;
           default = false;
         };
         clear_on_detach = mkOption {
           description = "Clear notification group when LSP server detaches";
-          type = types.bool;
+          type = bool;
           default = true;
           apply = clear:
             if clear
@@ -54,7 +60,7 @@ in {
         };
         notification_group = mkOption {
           description = "How to get a progress message's notification group key";
-          type = types.str;
+          type = str;
           default = ''
             function(msg)
               return msg.lsp_client.name
@@ -64,40 +70,40 @@ in {
         };
         ignore = mkOption {
           description = "Ignore LSP servers by name";
-          type = types.listOf types.str;
+          type = listOf str;
           default = [];
         };
 
         display = {
           render_limit = mkOption {
             description = "Maximum number of messages to render";
-            type = types.int;
+            type = int;
             default = 16;
           };
           done_ttl = mkOption {
             description = "How long a message should persist when complete";
-            type = types.int;
+            type = int;
             default = 3;
           };
           done_icon = mkOption {
             description = "Icon shown when LSP progress tasks are completed";
-            type = types.str;
+            type = str;
             default = "✓";
           };
           done_style = mkOption {
             description = "Highlight group for completed LSP tasks";
-            type = types.str;
+            type = str;
             default = "Constant";
           };
           progress_ttl = mkOption {
             description = "How long a message should persist when in progress";
-            type = types.int;
+            type = int;
             default = 99999;
           };
           progress_icon = {
             pattern = mkOption {
               description = "Pattern shown when LSP progress tasks are in progress";
-              type = types.enum [
+              type = enum [
                 "dots"
                 "dots_negative"
                 "dots_snake"
@@ -136,38 +142,38 @@ in {
             };
             period = mkOption {
               description = "Period of the pattern";
-              type = types.int;
+              type = int;
               default = 1;
             };
           };
           progress_style = mkOption {
             description = "Highlight group for in-progress LSP tasks";
-            type = types.str;
+            type = str;
             default = "WarningMsg";
           };
           group_style = mkOption {
             description = "Highlight group for group name (LSP server name)";
-            type = types.str;
+            type = str;
             default = "Title";
           };
           icon_style = mkOption {
             description = "Highlight group for group icons";
-            type = types.str;
+            type = str;
             default = "Question";
           };
           priority = mkOption {
             description = "Priority of the progress notification";
-            type = types.int;
+            type = int;
             default = 30;
           };
           skip_history = mkOption {
             description = "Skip adding messages to history";
-            type = types.bool;
+            type = bool;
             default = true;
           };
           format_message = mkOption {
             description = "How to format a progress message";
-            type = types.str;
+            type = str;
             default = ''
               require("fidget.progress.display").default_format_message
             '';
@@ -175,7 +181,7 @@ in {
           };
           format_annote = mkOption {
             description = "How to format a progress annotation";
-            type = types.str;
+            type = str;
             default = ''
               function(msg) return msg.title end
             '';
@@ -183,7 +189,7 @@ in {
           };
           format_group_name = mkOption {
             description = "How to format a progress notification group's name";
-            type = types.str;
+            type = str;
             default = ''
               function(group) return tostring(group) end
             '';
@@ -191,7 +197,7 @@ in {
           };
           overrides = mkOption {
             description = "Override options from the default notification config";
-            type = types.attrsOf types.str;
+            type = attrsOf str;
             default = {rust_analyzer = "{ name = 'rust-analyzer' }";};
             apply = mapAttrs (key: lua: rawLua lua);
           };
@@ -200,12 +206,12 @@ in {
         lsp = {
           progress_ringbuf_size = mkOption {
             description = "Nvim's LSP client ring buffer size";
-            type = types.int;
+            type = int;
             default = 100;
           };
           log_handler = mkOption {
             description = "Log `$/progress` handler invocations";
-            type = types.bool;
+            type = bool;
             default = false;
           };
         };
@@ -214,34 +220,34 @@ in {
       notification = {
         poll_rate = mkOption {
           description = "How frequently to update and render notifications";
-          type = types.int;
+          type = int;
           default = 10;
         };
         filter = mkOption {
           description = "Minimum notifications level";
-          type = types.enum ["debug" "info" "warn" "error"];
+          type = enum ["debug" "info" "warn" "error"];
           default = "info";
           apply = filter: rawLua "vim.log.levels.${toUpper filter}";
         };
         history_size = mkOption {
           description = "Number of removed messages to retain in history";
-          type = types.int;
+          type = int;
           default = 128;
         };
         override_vim_notify = mkOption {
           description = "Automatically override vim.notify() with Fidget";
-          type = types.bool;
+          type = bool;
           default = false;
         };
         configs = mkOption {
           description = "How to configure notification groups when instantiated";
-          type = types.attrsOf types.str;
+          type = attrsOf str;
           default = {default = "require('fidget.notification').default_config";};
           apply = mapAttrs (key: lua: rawLua lua);
         };
         redirect = mkOption {
           description = "Conditionally redirect notifications to another backend";
-          type = types.str;
+          type = str;
           default = ''
             function(msg, level, opts)
               if opts and opts.on_open then
@@ -255,27 +261,27 @@ in {
         view = {
           stack_upwards = mkOption {
             description = "Display notification items from bottom to top";
-            type = types.bool;
+            type = bool;
             default = true;
           };
           icon_separator = mkOption {
             description = "Separator between group name and icon";
-            type = types.str;
+            type = str;
             default = " ";
           };
           group_separator = mkOption {
             description = "Separator between notification groups";
-            type = types.str;
+            type = str;
             default = "---";
           };
           group_separator_hl = mkOption {
             description = "Highlight group used for group separator";
-            type = types.str;
+            type = str;
             default = "Comment";
           };
           render_message = mkOption {
             description = "How to render notification messages";
-            type = types.str;
+            type = str;
             default = ''
               function(msg, cnt)
                 return cnt == 1 and msg or string.format("(%dx) %s", cnt, msg)
@@ -288,17 +294,17 @@ in {
         window = {
           normal_hl = mkOption {
             description = "Base highlight group in the notification window";
-            type = types.str;
+            type = str;
             default = "Comment";
           };
           winblend = mkOption {
             description = "Background color opacity in the notification window";
-            type = types.int;
+            type = int;
             default = 100;
           };
           border = mkOption {
             description = "Border style of the notification window";
-            type = types.enum ["none" "single" "double" "rounded" "solid" "shadow"];
+            type = enum ["none" "single" "double" "rounded" "solid" "shadow"];
             default =
               if config.vim.ui.borders.enable
               then config.vim.ui.borders.globalStyle
@@ -306,37 +312,37 @@ in {
           };
           zindex = mkOption {
             description = "Stacking priority of the notification window";
-            type = types.int;
+            type = int;
             default = 45;
           };
           max_width = mkOption {
             description = "Maximum width of the notification window";
-            type = types.int;
+            type = int;
             default = 0;
           };
           max_height = mkOption {
             description = "Maximum height of the notification window";
-            type = types.int;
+            type = int;
             default = 0;
           };
           x_padding = mkOption {
             description = "Padding from right edge of window boundary";
-            type = types.int;
+            type = int;
             default = 1;
           };
           y_padding = mkOption {
             description = "Padding from bottom edge of window boundary";
-            type = types.int;
+            type = int;
             default = 0;
           };
           align = mkOption {
             description = "How to align the notification window";
-            type = types.enum ["top" "bottom"];
+            type = enum ["top" "bottom"];
             default = "bottom";
           };
           relative = mkOption {
             description = "What the notification window position is relative to";
-            type = types.enum ["editor" "win"];
+            type = enum ["editor" "win"];
             default = "editor";
           };
         };
@@ -346,7 +352,7 @@ in {
         nvim-tree = {
           enable = mkOption {
             description = "Integrate with nvim-tree/nvim-tree.lua (if enabled)";
-            type = types.bool;
+            type = bool;
             default =
               if config.vim.filetree.nvimTree.enable
               then true
@@ -356,7 +362,7 @@ in {
         xcodebuild-nvim = {
           enable = mkOption {
             description = "Integrate with wojciech-kulik/xcodebuild.nvim (if enabled)";
-            type = types.bool;
+            type = bool;
             default = true;
           };
         };
@@ -365,23 +371,23 @@ in {
       logger = {
         level = mkOption {
           description = "Minimum logging level";
-          type = types.enum ["debug" "error" "info" "trace" "warn" "off"];
+          type = enum ["debug" "error" "info" "trace" "warn" "off"];
           default = "warn";
           apply = logLevel: rawLua "vim.log.levels.${toUpper logLevel}";
         };
         max_size = mkOption {
           description = "Maximum log file size, in KB";
-          type = types.int;
+          type = int;
           default = 10000;
         };
         float_precision = mkOption {
           description = "Limit the number of decimals displayed for floats";
-          type = types.float;
+          type = float;
           default = 0.01;
         };
         path = mkOption {
           description = "Where Fidget writes its logs to";
-          type = types.str;
+          type = str;
           default = ''
             string.format("%s/fidget.nvim.log", vim.fn.stdpath("cache"))
           '';

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -3,7 +3,10 @@
   lib,
   ...
 }: let
-  inherit (lib) mkEnableOption mkMappingOption mkOption types literalExpression mkRenamedOptionModule mkRemovedOptionModule;
+  inherit (lib.modules) mkRemovedOptionModule mkRenamedOptionModule;
+  inherit (lib.options) mkEnableOption mkOption literalExpression;
+  inherit (lib.types) int bool str nullOr;
+  inherit (lib.nvim.binds) mkMappingOption;
 
   cfg = config.vim.visuals;
 in {
@@ -34,13 +37,13 @@ in {
       enable = mkEnableOption "line hightlighting on the cursor [nvim-cursorline]";
 
       lineTimeout = mkOption {
-        type = types.int;
+        type = int;
         description = "Time in milliseconds for cursorline to appear";
         default = 0;
       };
 
       lineNumbersOnly = mkOption {
-        type = types.bool;
+        type = bool;
         description = "Hightlight only in the presence of line numbers";
         default = true;
       };
@@ -49,21 +52,21 @@ in {
     indentBlankline = {
       enable = mkEnableOption "indentation guides [indent-blankline]";
       debounce = mkOption {
-        type = types.int;
+        type = int;
         description = "Debounce time in milliseconds";
         default = 200;
       };
 
       viewportBuffer = {
         min = mkOption {
-          type = types.int;
+          type = int;
           description = "Number of lines above and below of what is currently
             visible in the window";
           default = 30;
         };
 
         max = mkOption {
-          type = types.int;
+          type = int;
           description = "Number of lines above and below of what is currently
             visible in the window";
           default = 500;
@@ -72,34 +75,34 @@ in {
 
       indent = {
         char = mkOption {
-          type = types.str;
+          type = str;
           description = "Character for indentation line";
           default = "│";
         };
       };
 
       listChar = mkOption {
-        type = types.str;
+        type = str;
         description = "Character for indentation line";
         default = "│";
       };
 
       fillChar = mkOption {
         description = "Character to fill indents";
-        type = with types; nullOr types.str;
+        type = nullOr str;
         default = "⋅";
       };
 
       eolChar = mkOption {
         description = "Character at end of line";
-        type = with types; nullOr types.str;
+        type = nullOr str;
         default = "↴";
       };
 
       scope = {
         enabled = mkOption {
           description = "Highlight current scope from treesitter";
-          type = types.bool;
+          type = bool;
           default = config.vim.treesitter.enable;
           defaultText = literalExpression "config.vim.treesitter.enable";
         };
@@ -109,7 +112,7 @@ in {
             Displays the end of line character set by [](#opt-vim.visuals.indentBlankline.eolChar) instead of the
             indent guide on line returns.
           '';
-          type = types.bool;
+          type = bool;
           default = cfg.indentBlankline.eolChar != null;
           defaultText = literalExpression "config.vim.visuals.indentBlankline.eolChar != null";
         };
@@ -120,7 +123,7 @@ in {
       enable = mkEnableOption "highlight undo [highlight-undo]";
 
       highlightForCount = mkOption {
-        type = types.bool;
+        type = bool;
         default = true;
         description = ''
           Enable support for highlighting when a <count> is provided before the key
@@ -129,14 +132,14 @@ in {
       };
 
       duration = mkOption {
-        type = types.int;
+        type = int;
         description = "Duration of highlight";
         default = 500;
       };
 
       undo = {
         hlGroup = mkOption {
-          type = types.str;
+          type = str;
           description = "Highlight group for undo";
           default = "HighlightUndo";
         };
@@ -144,7 +147,7 @@ in {
 
       redo = {
         hlGroup = mkOption {
-          type = types.str;
+          type = str;
           description = "Highlight group for redo";
           default = "HighlightUndo";
         };


### PR DESCRIPTION
Should make almost all of the lib calls explicit. 

Renames the  function parameters of `diagnostics` option from `diagnostics` and `defaultDiagnostics` to `diagnosticsProviders` and `defaultDiagnosticsProvider` respectively, to avoid naming conflicts.