### PR TITLE
modules: clean up wrapper; extra wrapper features

### DIFF
--- a/docs/release-notes/rl-0.6.md
+++ b/docs/release-notes/rl-0.6.md
@@ -140,3 +140,8 @@ vim.api.nvim_set_keymap('n', '<leader>a', ':lua camelToSnake()<CR>', { noremap =
   and [`vim.spellChecking.programmingWordlist.enable`](vim.spellChecking.programmingWordlist.enable) for ignoring certain filetypes
   in spellchecking and enabling `vim-dirtytalk` respectively. The previously used `vim.spellcheck.vim-dirtytalk` aliases to the latter
   option.
+
+- Exposed `withRuby`, `withNodeJs`, `withPython3`, and `python3Packages` from the `makeNeovimConfig` function under their respective options.
+
+- Added [`vim.extraPackages`](vim.extraPackages) for appending additional packages to the wrapper PATH, making said packages available
+  while inside the Neovim session.

--- a/modules/neovim/mappings/default.nix
+++ b/modules/neovim/mappings/default.nix
@@ -1,6 +1,6 @@
 {
   imports = [
     ./config.nix
-    #./options.nix
+    ./options.nix
   ];
 }

--- a/modules/neovim/mappings/options.nix
+++ b/modules/neovim/mappings/options.nix
@@ -1,0 +1,101 @@
+{lib, ...}: let
+  inherit (lib.options) mkOption;
+  inherit (lib.types) bool str attrsOf nullOr submodule;
+  inherit (lib.nvim.config) mkBool;
+  # Most of the keybindings code is highly inspired by pta2002/nixvim.
+  # Thank you!
+  mapConfigOptions = {
+    silent =
+      mkBool false
+      "Whether this mapping should be silent. Equivalent to adding <silent> to a map.";
+
+    nowait =
+      mkBool false
+      "Whether to wait for extra input on ambiguous mappings. Equivalent to adding <nowait> to a map.";
+
+    script =
+      mkBool false
+      "Equivalent to adding <script> to a map.";
+
+    expr =
+      mkBool false
+      "Means that the action is actually an expression. Equivalent to adding <expr> to a map.";
+
+    unique =
+      mkBool false
+      "Whether to fail if the map is already defined. Equivalent to adding <unique> to a map.";
+
+    noremap =
+      mkBool true
+      "Whether to use the 'noremap' variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
+
+    desc = mkOption {
+      type = nullOr str;
+      default = null;
+      description = "A description of this keybind, to be shown in which-key, if you have it enabled.";
+    };
+  };
+
+  mapOption = submodule {
+    options =
+      mapConfigOptions
+      // {
+        action = mkOption {
+          type = str;
+          description = "The action to execute.";
+        };
+
+        lua = mkOption {
+          type = bool;
+          description = ''
+            If true, `action` is considered to be lua code.
+            Thus, it will not be wrapped in `""`.
+          '';
+          default = false;
+        };
+      };
+  };
+
+  mapOptions = mode:
+    mkOption {
+      description = "Mappings for ${mode} mode";
+      type = attrsOf mapOption;
+      default = {};
+    };
+in {
+  options.vim = {
+    maps = mkOption {
+      type = submodule {
+        options = {
+          normal = mapOptions "normal";
+          insert = mapOptions "insert";
+          select = mapOptions "select";
+          visual = mapOptions "visual and select";
+          terminal = mapOptions "terminal";
+          normalVisualOp = mapOptions "normal, visual, select and operator-pending (same as plain 'map')";
+
+          visualOnly = mapOptions "visual only";
+          operator = mapOptions "operator-pending";
+          insertCommand = mapOptions "insert and command-line";
+          lang = mapOptions "insert, command-line and lang-arg";
+          command = mapOptions "command-line";
+        };
+      };
+      default = {};
+      description = ''
+        Custom keybindings for any mode.
+
+        For plain maps (e.g. just 'map' or 'remap') use `maps.normalVisualOp`.
+      '';
+
+      example = ''
+        maps = {
+          normal."<leader>m" = {
+            silent = true;
+            action = "<cmd>make<CR>";
+          }; # Same as nnoremap <leader>m <silent> <cmd>make<CR>
+        };
+      '';
+    };
+  };
+}

--- a/modules/wrapper/build/options.nix
+++ b/modules/wrapper/build/options.nix
@@ -94,6 +94,16 @@ in {
       '';
     };
 
+    extraPackages = mkOption {
+      type = listOf package;
+      default = [];
+      example = literalExpression ''[pkgs.fzf pkgs.ripgrep]'';
+      description = ''
+        List of additional packages to make available to the Neovim
+        wrapper.
+      '';
+    };
+
     # this defaults to `true` in the wrapper
     # and since we passs this value to the wrapper
     # with an inherit, it should be `true` here as well

--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -1,77 +1,13 @@
 {
   config,
-  pkgs,
   lib,
   ...
 }: let
   inherit (lib.options) mkOption mkEnableOption literalMD literalExpression;
   inherit (lib.strings) optionalString;
-  inherit (lib.types) bool str oneOf attrsOf nullOr attrs submodule lines listOf either path;
+  inherit (lib.types) str oneOf attrs lines listOf either path;
   inherit (lib.nvim.types) dagOf;
   inherit (lib.nvim.lua) listToLuaTable;
-  inherit (lib.nvim.config) mkBool;
-
-  # Most of the keybindings code is highly inspired by pta2002/nixvim.
-  # Thank you!
-  mapConfigOptions = {
-    silent =
-      mkBool false
-      "Whether this mapping should be silent. Equivalent to adding <silent> to a map.";
-
-    nowait =
-      mkBool false
-      "Whether to wait for extra input on ambiguous mappings. Equivalent to adding <nowait> to a map.";
-
-    script =
-      mkBool false
-      "Equivalent to adding <script> to a map.";
-
-    expr =
-      mkBool false
-      "Means that the action is actually an expression. Equivalent to adding <expr> to a map.";
-
-    unique =
-      mkBool false
-      "Whether to fail if the map is already defined. Equivalent to adding <unique> to a map.";
-
-    noremap =
-      mkBool true
-      "Whether to use the 'noremap' variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
-
-    desc = mkOption {
-      type = nullOr str;
-      default = null;
-      description = "A description of this keybind, to be shown in which-key, if you have it enabled.";
-    };
-  };
-
-  mapOption = submodule {
-    options =
-      mapConfigOptions
-      // {
-        action = mkOption {
-          type = str;
-          description = "The action to execute.";
-        };
-
-        lua = mkOption {
-          type = bool;
-          description = ''
-            If true, `action` is considered to be lua code.
-            Thus, it will not be wrapped in `""`.
-          '';
-          default = false;
-        };
-      };
-  };
-
-  mapOptions = mode:
-    mkOption {
-      description = "Mappings for ${mode} mode";
-      type = attrsOf mapOption;
-      default = {};
-    };
-
   cfg = config.vim;
 in {
   options.vim = {
@@ -107,40 +43,6 @@ in {
       default = {};
       type = attrs;
       description = "Set containing global variable values";
-    };
-
-    maps = mkOption {
-      type = submodule {
-        options = {
-          normal = mapOptions "normal";
-          insert = mapOptions "insert";
-          select = mapOptions "select";
-          visual = mapOptions "visual and select";
-          terminal = mapOptions "terminal";
-          normalVisualOp = mapOptions "normal, visual, select and operator-pending (same as plain 'map')";
-
-          visualOnly = mapOptions "visual only";
-          operator = mapOptions "operator-pending";
-          insertCommand = mapOptions "insert and command-line";
-          lang = mapOptions "insert, command-line and lang-arg";
-          command = mapOptions "command-line";
-        };
-      };
-      default = {};
-      description = ''
-        Custom keybindings for any mode.
-
-        For plain maps (e.g. just 'map' or 'remap') use `maps.normalVisualOp`.
-      '';
-
-      example = ''
-        maps = {
-          normal."<leader>m" = {
-            silent = true;
-            action = "<cmd>make<CR>";
-          }; # Same as nnoremap <leader>m <silent> <cmd>make<CR>
-        };
-      '';
     };
 
     configRC = mkOption {

--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -5,7 +5,7 @@
 }: let
   inherit (lib.options) mkOption mkEnableOption literalMD literalExpression;
   inherit (lib.strings) optionalString;
-  inherit (lib.types) str oneOf attrs lines listOf either path;
+  inherit (lib.types) str oneOf attrs lines listOf either path bool;
   inherit (lib.nvim.types) dagOf;
   inherit (lib.nvim.lua) listToLuaTable;
   cfg = config.vim;
@@ -13,6 +13,15 @@ in {
   options.vim = {
     enableLuaLoader = mkEnableOption ''
       the experimental Lua module loader to speed up the start up process
+
+      If `true`, this will enable the experimental Lua module loader which:
+        - overrides loadfile
+        - adds the lua loader using the byte-compilation cache
+        - adds the libs loader
+        - removes the default Neovim loader
+
+      This is disabled by default. Before setting this option, please
+      take a look at the [{option}`official documentation`](https://neovim.io/doc/user/lua.html#vim.loader.enable()).
     '';
 
     additionalRuntimePaths = mkOption {
@@ -20,10 +29,11 @@ in {
       default = [];
       example = literalExpression ''
         [
-          "~/.config/nvim-extra" # absolute path, as a string - impure
+          "$HOME/.config/nvim-extra" # absolute path, as a string - impure
           ./nvim # relative path, as a path - pure
         ]
       '';
+
       description = ''
         Additional runtime paths that will be appended to the
         active runtimepath of the Neovim. This can be used to

--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -24,6 +24,26 @@ in {
       take a look at the [{option}`official documentation`](https://neovim.io/doc/user/lua.html#vim.loader.enable()).
     '';
 
+    disableDefaultRuntimePaths = mkOption {
+      type = bool;
+      default = true;
+      example = false;
+      description = ''
+        Disables the default runtime paths that are set by Neovim
+        when it starts up. This is useful when you want to have
+        full control over the runtime paths that are set by Neovim.
+
+        ::: {.note}
+        To avoid leaking imperative user configuration into your
+        configuration, this is enabled by default. If you wish
+        to load configuration from user configuration directories
+        (e.g. `$HOME/.config/nvim`, `$HOME/.config/nvim/after`
+        and `$HOME/.local/share/nvim/site`) you may set this
+        option to true.
+        :::
+      '';
+    };
+
     additionalRuntimePaths = mkOption {
       type = listOf (either path str);
       default = [];
@@ -88,6 +108,15 @@ in {
           for _, path in ipairs(additionalRuntimePaths) do
             vim.opt.runtimepath:append(path)
           end
+        ''}
+
+        ${optionalString cfg.disableDefaultRuntimePaths ''
+          -- Remove default user runtime paths from the
+          -- `runtimepath` option to avoid leaking user configuration
+          -- into the final neovim wrapper
+          vim.opt.runtimepath:remove(vim.fn.stdpath('config'))              -- $HOME/.config/nvim
+          vim.opt.runtimepath:remove(vim.fn.stdpath('config') .. "/after")  -- $HOME/.config/nvim/after
+          vim.opt.runtimepath:remove(vim.fn.stdpath('data') .. "/site")     -- $HOME/.local/share/nvim/site
         ''}
 
         ${optionalString cfg.enableLuaLoader "vim.loader.enable()"}


### PR DESCRIPTION
- Exposes more basic wrapper features (such as `withRuby`, `withNodeJs`, `withPython3`, and `python3Packages`) to the user configuration.
- Performs internal refactoring to make `modules` directory more readable and easily traversable.
- Adds `extraPackages`, which takes a list of packages, that will be passed to the wrapper's `PATH` during build.