### PR TITLE
language/nix: add treesitter queries for nvf idioms

### DIFF
--- a/flake/legacyPackages.nix
+++ b/flake/legacyPackages.nix
@@ -17,6 +17,9 @@
           # Build nil from source to get most recent
           # features as they are added.
           nil = inputs'.nil.packages.default;
+          nvf-queries = final.callPackage ./legacyPackages/nvf-queries.nix {
+            version = self.shortRev or self.dirtyShortRev or "dirty";
+          };
           blink-cmp = let
             pin = self.pins.blink-cmp;
           in

--- a/flake/legacyPackages/nvf-queries.nix
+++ b/flake/legacyPackages/nvf-queries.nix
@@ -1,0 +1,10 @@
+{
+  vimUtils,
+  version,
+}:
+vimUtils.buildVimPlugin {
+  pname = "nvf-queries";
+  inherit version;
+
+  src = ./nvf-queries;
+}

--- a/flake/legacyPackages/nvf-queries/queries/nix/injections.scm
+++ b/flake/legacyPackages/nvf-queries/queries/nix/injections.scm
@@ -1,0 +1,35 @@
+; extends
+
+(binding
+  attrpath: (attrpath
+    (identifier) @_path)
+  expression: [
+    (string_expression
+      (string_fragment) @injection.content)
+    (indented_string_expression
+      (string_fragment) @injection.content)
+  ]
+  (#set! injection.language "lua")
+  (#match? @_path "^luaConfig\(Pre\|Post\)$"))
+
+(apply_expression
+  function: [
+    (variable_expression
+      name: (identifier) @funcName
+      (#eq? @funcName "mkLuaInline"))
+    ;; matches lib.generators.mkLuaInline
+    (select_expression
+      expression: _ @lib
+      (#eq? @lib "lib")
+      (attrpath
+        attr: (identifier) @generators
+        attr: (identifier) @funcName)
+        (#eq? @generators "generators"))
+  ]
+  argument: [
+    (string_expression
+      (string_fragment) @injection.content)
+    (indented_string_expression
+      (string_fragment) @injection.content)
+  ]
+  (#set! injection.language "lua"))

--- a/flake/legacyPackages/nvf-queries/queries/nix/injections.scm
+++ b/flake/legacyPackages/nvf-queries/queries/nix/injections.scm
@@ -33,3 +33,21 @@
       (string_fragment) @injection.content)
   ]
   (#set! injection.language "lua"))
+
+(apply_expression
+  function: (apply_expression
+    function: [
+      (variable_expression
+        name: (identifier) @_func)
+      ;; matches lib.nvim.bla.bla.entryBefore
+      (select_expression
+        expression: (variable_expression)
+        attrpath: (attrpath
+          attr: (identifier) @_func .))
+    ]
+    argument: _)
+  argument: (indented_string_expression
+    (string_fragment) @injection.content)
+  (#match? @_func "^entry(Anywhere|After|Before)$")
+  (#set! injection.language "lua")
+  (#set! injection.combined))

--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -18,7 +18,7 @@
   pluginType = nullOr (
     either
     package
-    (enum (pluginInputNames ++ ["nvim-treesitter" "flutter-tools-patched" "vim-repeat"]))
+    (enum (pluginInputNames ++ ["nvim-treesitter" "flutter-tools-patched" "vim-repeat" "nvf-queries"]))
   );
 
   pluginsType = listOf pluginType;

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -140,6 +140,13 @@ in {
     treesitter = {
       enable = mkEnableOption "Nix treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = mkGrammarOption pkgs "nix";
+
+      enableNvfQueries =
+        mkEnableOption ''
+          extra query files targetted at nvf configuration, e.g. injection rules
+          for mkLuaInline and some options.
+        ''
+        // {default = true;};
     };
 
     lsp = {
@@ -212,8 +219,11 @@ in {
     }
 
     (mkIf cfg.treesitter.enable {
-      vim.treesitter.enable = true;
-      vim.treesitter.grammars = [cfg.treesitter.package];
+      vim = {
+        treesitter.enable = true;
+        treesitter.grammars = [cfg.treesitter.package];
+        startPlugins = mkIf cfg.treesitter.enableNvfQueries ["nvf-queries"];
+      };
     })
 
     (mkIf cfg.lsp.enable {

--- a/modules/wrapper/build/config.nix
+++ b/modules/wrapper/build/config.nix
@@ -51,7 +51,7 @@
       doCheck = false;
     };
 
-    inherit (inputs.self.legacyPackages.${pkgs.stdenv.system}) blink-cmp;
+    inherit (inputs.self.legacyPackages.${pkgs.stdenv.system}) blink-cmp nvf-queries;
   };
 
   buildConfigPlugins = plugins:


### PR DESCRIPTION
todo: unsure if the current approach works robustly - our query has the same level of priority as nvim-treesitter in terms of rtp ordering, does this guarantee that ours will be loaded along with nvim-ts's or do we need to prepend ours in rtp?