### PR TITLE
avante-nvim: remove unnecessary dependencies in plugin build

### DIFF
--- a/flake/avante-nvim/default.nix
+++ b/flake/avante-nvim/default.nix
@@ -1,16 +1,14 @@
 {
-  nix-update-script,
   openssl,
   pkg-config,
   rustPlatform,
   stdenv,
-  vimPlugins,
   vimUtils,
   makeWrapper,
   pkgs,
   version,
   src,
-  pins,
+  ...
 }: let
   inherit version src;
   avante-nvim-lib = rustPlatform.buildRustPackage {
@@ -45,20 +43,7 @@ in
     pname = "avante-nvim";
     inherit version src;
 
-    dependencies =
-      [vimPlugins.nvim-treesitter]
-      ++ (builtins.map (name: let
-        pin = pins.${name};
-      in
-        pkgs.fetchFromGitHub {
-          inherit (pin.repository) owner repo;
-          rev = pin.revision;
-          sha256 = pin.hash;
-        }) [
-        "dressing-nvim"
-        "plenary-nvim"
-        "nui-nvim"
-      ]);
+    doCheck = false;
 
     postInstall = let
       ext = stdenv.hostPlatform.extensions.sharedLibrary;


### PR DESCRIPTION
As described in https://github.com/NotAShelf/nvf/pull/934#issuecomment-2937368328 this is my take to remove the unwanted dependencies during the vim plugin build process.

My guess is that the plugin build is only necessary because of some shared libraries (flake/avante-nvim/default.nix:52), unfortunately I was unable to find another way to set them for the plugin itself.

If anyone can show some insights on how a change would look like I am happy to try it again, otherwise this is the best I can do for now.