### PR TITLE
wrapper/options: fix exmple for `additionalRuntimePaths`

### DIFF
--- a/modules/plugins/dashboard/startify/startify.nix
+++ b/modules/plugins/dashboard/startify/startify.nix
@@ -3,46 +3,47 @@
   inherit (lib.types) listOf attrs bool enum str oneOf int;
 in {
   options.vim.dashboard.startify = {
-    enable = mkEnableOption "dashboard via vim-startify";
+    enable = mkEnableOption "fancy start screen for Vim [vim-startify]";
 
     bookmarks = mkOption {
-      default = [];
-      description = ''List of book marks to disaply on start page'';
       type = listOf attrs;
+      default = [];
       example = {"c" = "~/.vimrc";};
+      description = "List of book marks to display on start page";
     };
 
     changeToDir = mkOption {
-      default = true;
-      description = "Should vim change to the directory of the file you open";
       type = bool;
+      default = true;
+      description = "Whether Vim should change to the directory of the file you open";
     };
 
     changeToVCRoot = mkOption {
-      default = false;
-      description = "Should vim change to the version control root when opening a file";
       type = bool;
+      default = false;
+      description = "Whether Vim should change to the version control root when opening a file";
     };
 
     changeDirCmd = mkOption {
-      default = "lcd";
-      description = "Command to change the current window with. Can be cd, lcd or tcd";
       type = enum ["cd" "lcd" "tcd"];
+      default = "lcd";
+      description = "Command to change the current window with.";
     };
 
     customHeader = mkOption {
+      type = listOf str;
       default = [];
       description = "Text to place in the header";
-      type = listOf str;
     };
 
     customFooter = mkOption {
+      type = listOf str;
       default = [];
       description = "Text to place in the footer";
-      type = listOf str;
     };
 
     lists = mkOption {
+      type = listOf attrs;
       default = [
         {
           type = "files";
@@ -66,121 +67,136 @@ in {
         }
       ];
       description = "Specify the lists and in what order they are displayed on startify.";
-      type = listOf attrs;
     };
 
     skipList = mkOption {
+      type = listOf str;
       default = [];
       description = "List of regex patterns to exclude from MRU lists";
-      type = listOf str;
     };
 
     updateOldFiles = mkOption {
+      type = bool;
+
       default = false;
       description = "Set if you want startify to always update and not just when neovim closes";
-      type = bool;
     };
 
     sessionAutoload = mkOption {
-      default = false;
-      description = "Make startify auto load Session.vim files from the current directory";
       type = bool;
+
+      default = false;
+      description = "Make vim-startify auto load Session.vim files from the current directory";
     };
 
     commands = mkOption {
+      type = listOf (oneOf [str attrs (listOf str)]);
       default = [];
       description = "Commands that are presented to the user on startify page";
-      type = listOf (oneOf [str attrs (listOf str)]);
     };
 
     filesNumber = mkOption {
+      type = int;
       default = 10;
       description = "How many files to list";
-      type = int;
     };
 
     customIndices = mkOption {
+      type = listOf str;
       default = [];
       description = "Specify a list of default characters to use instead of numbers";
-      type = listOf str;
     };
 
     disableOnStartup = mkOption {
-      default = false;
-      description = "Prevent startify from opening on startup but can be called with :Startify";
       type = bool;
+      default = false;
+      description = ''
+        Whether vim-startify should be disabled on startup.
+
+        This will prevent startify from opening on startup, but it can still
+        be called with `:Startify`
+      '';
     };
 
     unsafe = mkOption {
-      default = false;
-      description = "Turns on unsafe mode for Startify. Stops resolving links, checking files are readable and filtering bookmark list";
       type = bool;
+      default = false;
+      description = ''
+        Whether to turn on unsafe mode for Startify.
+
+        While enabld, vim-startify will stops resolving links, checking files
+        are readable and filtering bookmark list
+      '';
     };
 
     paddingLeft = mkOption {
+      type = int;
       default = 3;
       description = "Number of spaces used for left padding.";
-      type = int;
     };
 
     useEnv = mkOption {
+      type = bool;
       default = false;
       description = "Show environment variables in path if name is shorter than value";
-      type = bool;
     };
 
     sessionBeforeSave = mkOption {
+      type = listOf str;
       default = [];
       description = "Commands to run before saving a session";
-      type = listOf str;
     };
 
     sessionPersistence = mkOption {
+      type = bool;
       default = false;
       description = "Persist session before leaving vim or switching session";
-      type = bool;
     };
 
     sessionDeleteBuffers = mkOption {
+      type = bool;
       default = true;
       description = "Delete all buffers when loading or closing a session";
-      type = bool;
     };
 
     sessionDir = mkOption {
+      type = str;
       default = "~/.vim/session";
       description = "Directory to save and load sessions from";
-      type = str;
     };
 
     skipListServer = mkOption {
+      type = listOf str;
       default = [];
       description = "List of vim servers to not load startify for";
-      type = listOf str;
     };
 
     sessionRemoveLines = mkOption {
+      type = listOf str;
       default = [];
       description = "Patterns to remove from session files";
-      type = listOf str;
     };
 
     sessionSavevars = mkOption {
+      type = listOf str;
       default = [];
       description = "List of variables to save into a session file.";
-      type = listOf str;
     };
 
     sessionSavecmds = mkOption {
+      type = listOf str;
       default = [];
       description = "List of commands to run when loading a session.";
-      type = listOf str;
     };
 
     sessionSort = mkOption {
-      default = false;
-      description = "Set if you want items sorted by date rather than alphabetically";
       type = bool;
+      default = false;
+      example = true;
+      description = ''
+        While true, sessions will be sorted by date rather than alphabetically.
+
+      '';
     };
   };
 }

--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -36,7 +36,7 @@ in {
           # Absolute path, as a string. This is the impure option.
           "$HOME/.config/nvim-extra"
 
-          # Relative path inside your configurationn. If your config
+          # Relative path inside your configuration. If your config
           # is version controlled, then this is pure and reproducible.
           ./nvim
 


### PR DESCRIPTION
Reported on Discord. Fixes the incorrect example and revamps wording a little.