### PR TITLE
themes/catppuccin: propagate transparency to floating window options

### DIFF
--- a/modules/plugins/theme/supported-themes.nix
+++ b/modules/plugins/theme/supported-themes.nix
@@ -71,6 +71,9 @@ in {
       require('catppuccin').setup {
         flavour = "${style}",
         transparent_background = ${boolToString transparent},
+        float = {
+          transparent = ${boolToString transparent},
+        },
         term_colors = true,
         integrations = {
           nvimtree = {


### PR DESCRIPTION
The latest plugin update c5ed9b3 brought in this change https://github.com/catppuccin/nvim/pull/892, which introduces a separate transparency option for floating windows. In order to preserve the previous behavior, the theme transparency flag was used as the value for this new option.

I can see some people preferring the new look, however I  wasn't able to find a way to customize/override the theme setup. 

<img width="1884" height="2058" alt="image" src="https://github.com/user-attachments/assets/1ae5eaca-db6f-496c-881f-7fb4bb5566eb" />


Before:
<img width="1887" height="1078" alt="image" src="https://github.com/user-attachments/assets/f0e4836b-bc1a-41a4-ae84-1887e8a3033e" />
<img width="1894" height="1095" alt="image" src="https://github.com/user-attachments/assets/bc38d5ca-d3b7-481c-9cc7-2de97eec9570" />

After:
<img width="1891" height="1051" alt="image" src="https://github.com/user-attachments/assets/9ad1809c-4b66-4166-9eb0-9d976af38023" />
<img width="1899" height="1083" alt="image" src="https://github.com/user-attachments/assets/064e1463-6302-4de0-8ede-3f3c94655ac9" />

Transparency false behavior remains the same.
<img width="1873" height="997" alt="image" src="https://github.com/user-attachments/assets/a46adf1d-1115-45fe-924a-556c3c9b739e" />
<img width="1842" height="1978" alt="image" src="https://github.com/user-attachments/assets/a4545310-73e9-4427-b854-4acc0c6cc446" />


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
