### PR TITLE
treewide: don't import modules manually

### DIFF
--- a/modules/plugins/assistant/chatgpt/config.nix
+++ b/modules/plugins/assistant/chatgpt/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -10,8 +11,7 @@
 
   cfg = config.vim.assistant.chatgpt;
 
-  self = import ./chatgpt.nix {inherit lib;};
-  mappingDefinitions = self.options.vim.assistant.chatgpt.mappings;
+  mappingDefinitions = options.vim.assistant.chatgpt.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
   maps = mkMerge [
     (mkSetBinding mappings.editWithInstructions "<cmd>ChatGPTEditWithInstruction<CR>")

--- a/modules/plugins/git/git-conflict/config.nix
+++ b/modules/plugins/git/git-conflict/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -10,8 +11,7 @@
 
   cfg = config.vim.git.git-conflict;
 
-  self = import ./git-conflict.nix {inherit lib config;};
-  gcMappingDefinitions = self.options.vim.git.git-conflict.mappings;
+  gcMappingDefinitions = options.vim.git.git-conflict.mappings;
 
   gcMappings = addDescriptionsToMappings cfg.mappings gcMappingDefinitions;
 in {

--- a/modules/plugins/git/gitsigns/config.nix
+++ b/modules/plugins/git/gitsigns/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (builtins) toJSON;
@@ -12,8 +13,7 @@
 
   cfg = config.vim.git.gitsigns;
 
-  self = import ./gitsigns.nix {inherit lib config;};
-  gsMappingDefinitions = self.options.vim.git.gitsigns.mappings;
+  gsMappingDefinitions = options.vim.git.gitsigns.mappings;
 
   gsMappings = addDescriptionsToMappings cfg.mappings gsMappingDefinitions;
 in {

--- a/modules/plugins/lsp/config.nix
+++ b/modules/plugins/lsp/config.nix
@@ -1,7 +1,7 @@
 {
   config,
   lib,
-  pkgs,
+  options,
   ...
 }: let
   inherit (lib.generators) mkLuaInline;
@@ -14,12 +14,11 @@
   cfg = config.vim.lsp;
   usingNvimCmp = config.vim.autocomplete.nvim-cmp.enable;
   usingBlinkCmp = config.vim.autocomplete.blink-cmp.enable;
-  self = import ./module.nix {inherit config lib pkgs;};
   conformCfg = config.vim.formatter.conform-nvim;
   conformFormatOnSave = conformCfg.enable && conformCfg.setupOpts.format_on_save != null;
 
   augroup = "nvf_lsp";
-  mappingDefinitions = self.options.vim.lsp.mappings;
+  mappingDefinitions = options.vim.lsp.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
   mkBinding = binding: action:
     if binding.value != null

--- a/modules/plugins/lsp/nvim-docs-view/config.nix
+++ b/modules/plugins/lsp/nvim-docs-view/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -9,9 +10,8 @@
   inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.lsp.nvim-docs-view;
-  self = import ./nvim-docs-view.nix {inherit lib;};
 
-  mappingDefinitions = self.options.vim.lsp.nvim-docs-view.mappings;
+  mappingDefinitions = options.vim.lsp.nvim-docs-view.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
   config = mkIf cfg.enable {

--- a/modules/plugins/lsp/otter/config.nix
+++ b/modules/plugins/lsp/otter/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -10,8 +11,7 @@
 
   cfg = config.vim.lsp;
 
-  self = import ./otter.nix {inherit lib;};
-  mappingDefinitions = self.options.vim.lsp.otter-nvim.mappings;
+  mappingDefinitions = options.vim.lsp.otter-nvim.mappings;
   mappings = addDescriptionsToMappings cfg.otter-nvim.mappings mappingDefinitions;
 in {
   config = mkIf (cfg.enable && cfg.otter-nvim.enable) {

--- a/modules/plugins/minimap/codewindow/config.nix
+++ b/modules/plugins/minimap/codewindow/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -9,9 +10,7 @@
 
   cfg = config.vim.minimap.codewindow;
 
-  self = import ./codewindow.nix {inherit lib;};
-
-  mappingDefinitions = self.options.vim.minimap.codewindow.mappings;
+  mappingDefinitions = options.vim.minimap.codewindow.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
   config = mkIf cfg.enable {

--- a/modules/plugins/notes/todo-comments/config.nix
+++ b/modules/plugins/notes/todo-comments/config.nix
@@ -1,7 +1,7 @@
 {
-  pkgs,
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkMerge mkIf;
@@ -9,8 +9,7 @@
   inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.notes.todo-comments;
-  self = import ./todo-comments.nix {inherit pkgs lib;};
-  inherit (self.options.vim.notes.todo-comments) mappings;
+  inherit (options.vim.notes.todo-comments) mappings;
 in {
   config = mkIf cfg.enable {
     vim = {

--- a/modules/plugins/tabline/nvim-bufferline/config.nix
+++ b/modules/plugins/tabline/nvim-bufferline/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -9,8 +10,8 @@
   inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.tabline.nvimBufferline;
-  self = import ./nvim-bufferline.nix {inherit config lib;};
-  inherit (self.options.vim.tabline.nvimBufferline) mappings;
+
+  inherit (options.vim.tabline.nvimBufferline) mappings;
 in {
   config = mkIf cfg.enable {
     vim = {

--- a/modules/plugins/treesitter/config.nix
+++ b/modules/plugins/treesitter/config.nix
@@ -1,7 +1,7 @@
 {
   config,
-  pkgs,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -12,8 +12,7 @@
 
   cfg = config.vim.treesitter;
 
-  self = import ./treesitter.nix {inherit pkgs lib;};
-  mappingDefinitions = self.options.vim.treesitter.mappings;
+  mappingDefinitions = options.vim.treesitter.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
   config = mkIf cfg.enable {

--- a/modules/plugins/utility/gestures/gesture-nvim/config.nix
+++ b/modules/plugins/utility/gestures/gesture-nvim/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -9,9 +10,7 @@
 
   cfg = config.vim.gestures.gesture-nvim;
 
-  self = import ./gesture-nvim.nix {inherit lib;};
-
-  mappingDefinitions = self.options.vim.gestures.gesture-nvim.mappings;
+  mappingDefinitions = options.vim.gestures.gesture-nvim.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
   config = mkIf cfg.enable {

--- a/modules/plugins/utility/motion/hop/config.nix
+++ b/modules/plugins/utility/motion/hop/config.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf;
@@ -9,9 +10,7 @@
 
   cfg = config.vim.utility.motion.hop;
 
-  self = import ./hop.nix {inherit lib;};
-
-  mappingDefinitions = self.options.vim.utility.motion.hop.mappings;
+  mappingDefinitions = options.vim.utility.motion.hop.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
   config = mkIf cfg.enable {

--- a/modules/plugins/utility/preview/glow/config.nix
+++ b/modules/plugins/utility/preview/glow/config.nix
@@ -2,6 +2,7 @@
   pkgs,
   config,
   lib,
+  options,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -9,10 +10,7 @@
   inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.utility.preview.glow;
-  self = import ./glow.nix {
-    inherit lib config pkgs;
-  };
-  inherit (self.options.vim.utility.preview.glow) mappings;
+  inherit (options.vim.utility.preview.glow) mappings;
 in {
   config = mkIf cfg.enable {
     vim.startPlugins = ["glow-nvim"];


### PR DESCRIPTION
These are all cases where just using another module argument works better,
and adapts to codebase changes more easily.

I'm trying to figure out the default keymap toggle issue and having multiple entrypoints to some modules makes `sed` less universal.

This seems like technical debt that just hasn't yet been removed, so I figured I should just PR it asap separately.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
   Evaluation is exactly the same.
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
