### PR TITLE
languages/rust: move `crates.nvim` dependency to `extensions` modernize

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -115,6 +115,9 @@
 - Add [hunk.nvim], Neovim plugin & tool for splitting diffs in Neovim. Available
   as `vim.git.hunk-nvim`
 
+- Move `crates.nvim` into `languages.rust.extensions and support` `setupOpts`
+  for the plugin. Deprecates the top level "crates" option in `languages.rust`.
+
 [sjcobb2022](https://github.com/sjcobb2022):
 
 - Migrate all current lsp configurations to `vim.lsp.server` and remove internal

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -4,16 +4,15 @@
   lib,
   ...
 }: let
-  inherit (builtins) attrNames;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkOption mkEnableOption literalMD;
   inherit (lib.strings) optionalString;
-  inherit (lib.trivial) boolToString;
   inherit (lib.lists) isList;
+  inherit (lib.attrsets) attrNames;
   inherit (lib.types) bool package str listOf either enum;
-  inherit (lib.nvim.types) mkGrammarOption;
-  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption;
+  inherit (lib.nvim.lua) expToLua toLuaObject;
   inherit (lib.nvim.dag) entryAfter entryAnywhere;
 
   cfg = config.vim.languages.rust;
@@ -31,15 +30,6 @@ in {
     treesitter = {
       enable = mkEnableOption "Rust treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = mkGrammarOption pkgs "rust";
-    };
-
-    crates = {
-      enable = mkEnableOption "crates-nvim, tools for managing dependencies";
-      codeActions = mkOption {
-        description = "Enable code actions through null-ls";
-        type = bool;
-        default = true;
-      };
     };
 
     lsp = {
@@ -103,25 +93,32 @@ in {
         default = pkgs.lldb;
       };
     };
+
+    extensions = {
+      crates-nvim = {
+        enable = mkEnableOption "crates.io dependency management [crates-nvim]";
+
+        setupOpts = mkPluginSetupOption "crates-nvim" {
+          completion.enable = mkOption {
+            type = bool;
+            default = config.vim.autocomplete.nvim-cmp.enable;
+            defaultText = "{option}`config.vim.autocomplete.nvim-cmp.enable`";
+            description = ''
+              Whether to add crates.nvim as a source for completion plugins. The following
+              plugins are supported by crates.nvim:
+
+              * nvim-cmp
+              * coq.nvim
+
+              However nvf only supports auto-setup for nvim-cmp.
+            '';
+          };
+        };
+      };
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
-    (mkIf cfg.crates.enable {
-      vim = {
-        startPlugins = ["crates-nvim"];
-        lsp.null-ls.enable = mkIf cfg.crates.codeActions true;
-        autocomplete.nvim-cmp.sources = {crates = "[Crates]";};
-        pluginRC.rust-crates = entryAnywhere ''
-          require('crates').setup {
-            null_ls = {
-              enabled = ${boolToString cfg.crates.codeActions},
-              name = "crates.nvim",
-            }
-          }
-        '';
-      };
-    })
-
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
       vim.treesitter.grammars = [cfg.treesitter.package];
@@ -140,7 +137,6 @@ in {
     (mkIf (cfg.lsp.enable || cfg.dap.enable) {
       vim = {
         startPlugins = ["rustaceanvim"];
-
         pluginRC.rustaceanvim = entryAfter ["lsp-setup"] ''
           vim.g.rustaceanvim = {
           ${optionalString cfg.lsp.enable ''
@@ -153,13 +149,14 @@ in {
             server = {
               cmd = ${
               if isList cfg.lsp.package
-              then toLuaObject cfg.lsp.package
+              then expToLua cfg.lsp.package
               else ''{"${cfg.lsp.package}/bin/rust-analyzer"}''
             },
               default_settings = {
                 ${cfg.lsp.opts}
               },
               on_attach = function(client, bufnr)
+                default_on_attach(client, bufnr)
                 local opts = { noremap=true, silent=true, buffer = bufnr }
                 vim.keymap.set("n", "<localleader>rr", ":RustLsp runnables<CR>", opts)
                 vim.keymap.set("n", "<localleader>rp", ":RustLsp parentModule<CR>", opts)
@@ -197,6 +194,29 @@ in {
           }
         '';
       };
+    })
+
+    (mkIf cfg.extensions.crates-nvim.enable {
+      vim = let
+        withCompletion = cfg.extensions.crates-nvim.withCmpSource;
+      in
+        mkMerge [
+          {
+            startPlugins = ["crates-nvim"];
+            pluginRC.rust-crates = entryAnywhere ''
+              require("crates").setup(${toLuaObject cfg.extensions.crates-nvim.setupOpts})
+            '';
+          }
+
+          # FIXME: this will not be necessary once crates.nvim creates a new release that
+          # ships improvements to the in-progress LSP module. If updating > 0.7.1, remember
+          # to update this section.
+          # See:
+          #  <https://github.com/saecki/crates.nvim/wiki/Documentation-unstable#auto-completion>
+          (mkIf withCompletion {
+            autocomplete.nvim-cmp.sources = {crates = "[Crates]";};
+          })
+        ];
     })
   ]);
 }


### PR DESCRIPTION
Partially supersedes #1185 

I've decided to do it one-by-one so we can manage the diffs and revert with granularity.