### PR TITLE
treewide: avoid builtins.warn for compatibility with older nix

### DIFF
--- a/lib/types/custom.nix
+++ b/lib/types/custom.nix
@@ -1,9 +1,10 @@
 {lib}: let
-  inherit (builtins) warn toJSON;
+  inherit (builtins) toJSON;
   inherit (lib.options) mergeEqualOption;
   inherit (lib.lists) singleton;
   inherit (lib.strings) isString stringLength match;
   inherit (lib.types) listOf mkOptionType coercedTo;
+  inherit (lib.trivial) warn;
 in {
   mergelessListOf = elemType:
     mkOptionType {

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -1,8 +1,9 @@
 {lib, ...}: let
-  inherit (builtins) head warn;
+  inherit (builtins) head;
   inherit (lib.modules) mkRemovedOptionModule mkRenamedOptionModule doRename;
   inherit (lib.lists) concatLists;
   inherit (lib.nvim.config) batchRenameOptions;
+  inherit (lib.trivial) warn;
 
   renamedVimOpts = batchRenameOptions ["vim"] ["vim" "options"] {
     # 2024-12-01

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -4,7 +4,7 @@
   lib,
   ...
 }: let
-  inherit (builtins) attrNames warn;
+  inherit (builtins) attrNames;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkEnableOption mkOption;
@@ -13,6 +13,7 @@
   inherit (lib.nvim.types) diagnostics mkGrammarOption mkPluginSetupOption deprecatedSingleOrListOf;
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.attrsets) mapListToAttrs;
+  inherit (lib.trivial) warn;
 
   cfg = config.vim.languages.markdown;
   defaultServers = ["marksman"];

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -4,7 +4,7 @@
   lib,
   ...
 }: let
-  inherit (builtins) attrNames warn;
+  inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.lists) flatten;
   inherit (lib.meta) getExe getExe';
@@ -14,6 +14,7 @@
   inherit (lib.nvim.types) deprecatedSingleOrListOf;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.dag) entryBefore;
+  inherit (lib.trivial) warn;
 
   cfg = config.vim.languages.python;
 


### PR DESCRIPTION
fixes #1227 