### PR TITLE
feat(tailwind): allow for custom options in LSP (example with `cva`)

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -510,3 +510,8 @@
 
 - Add inline typst concealing support under `vim.languages.typst` using
   [typst-concealer].
+
+[Shyrogan](https://github.com/Shyrogan):
+
+- Add `vim.languages.tailwind.lsp.opts` option to Tailwind (for third party such as 
+  [cva](https://beta.cva.style/)) along an example on how to use it.

--- a/modules/plugins/languages/tailwind.nix
+++ b/modules/plugins/languages/tailwind.nix
@@ -21,6 +21,11 @@
         lspconfig.tailwindcss.setup {
           capabilities = capabilities;
           on_attach = default_on_attach;
+          settings = {
+            tailwindCSS = {
+              ${cfg.lsp.opts}
+            },
+          },
           cmd = ${
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package
@@ -48,6 +53,19 @@ in {
         example = ''[lib.getExe pkgs.jdt-language-server " - data " " ~/.cache/jdtls/workspace "]'';
         type = either package (listOf str);
         default = servers.${cfg.lsp.server}.package;
+      };
+
+      opts = mkOption {
+        description = "Options to pass to tailwindcss-lsp";
+        type = str;
+        default = "";
+        example = ''
+          experimental = {
+            classRegex = {
+              { "cva\\(([^)]*)\\)", "[\"'`]([^\"'`]+)[\"'`]" },
+            },
+          },
+        '';
       };
     };
   };


### PR DESCRIPTION
This pull requests allows the user to configure the tailwind LSP. This is especially use if you use third party libraries or front-end framework with a different syntax than just React's `className`/HTML `class` attribute.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
