### PR TITLE
feat(autocompletion): allow blink-cmp package override

### DIFF
--- a/modules/plugins/completion/blink-cmp/blink-cmp.nix
+++ b/modules/plugins/completion/blink-cmp/blink-cmp.nix
@@ -1,5 +1,5 @@
-{lib, ...}: let
-  inherit (lib.options) mkEnableOption mkOption literalMD;
+{lib, pkgs, ...}: let
+  inherit (lib.options) mkEnableOption mkOption mkPackageOption literalMD;
   inherit (lib.types) bool listOf str either attrsOf submodule enum anything int nullOr;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline pluginType;
   inherit (lib.nvim.binds) mkMappingOption;
@@ -29,6 +29,7 @@
 in {
   options.vim.autocomplete.blink-cmp = {
     enable = mkEnableOption "blink.cmp";
+    package = mkPackageOption pkgs ["vimPlugins" "blink-cmp"] { nullable = true; };
     setupOpts = mkPluginSetupOption "blink.cmp" {
       sources = {
         default = mkOption {

--- a/modules/plugins/completion/blink-cmp/config.nix
+++ b/modules/plugins/completion/blink-cmp/config.nix
@@ -17,7 +17,9 @@
   inherit (cfg) mappings;
 
   getPluginName = plugin:
-    if typeOf plugin == "string"
+    if cfg.package != null
+      then cfg.package.pname
+    else if typeOf plugin == "string"
     then plugin
     else if (plugin ? pname && (tryEval plugin.pname).success)
     then plugin.pname
@@ -43,9 +45,11 @@ in {
 
   vim = mkIf cfg.enable {
     startPlugins = ["blink-compat"] ++ blinkSourcePlugins ++ (optional cfg.friendly-snippets.enable "friendly-snippets");
-    lazy.plugins = {
-      blink-cmp = {
-        package = "blink-cmp";
+    lazy.plugins = let
+      pluginName = if cfg.package != null then cfg.package.pname else "blink-cmp";
+    in {
+      "${pluginName}" = {
+        package = if cfg.package == null then "blink-cmp" else cfg.package;
         setupModule = "blink.cmp";
         inherit (cfg) setupOpts;
 


### PR DESCRIPTION
blink-cmp is broken because of some rust flags that need to be passed in (See https://github.com/NixOS/nixpkgs/pull/464350). Had to fork so it would be nice if you could override the package as in this PR.