### PR TITLE
noice: message, notify, health options

### DIFF
--- a/modules/plugins/ui/noice/noice.nix
+++ b/modules/plugins/ui/noice/noice.nix
@@ -29,6 +29,60 @@ in {
         };
       };
 
+      messages = {
+        enabled =
+          mkEnableOption "Noice messages UI"
+          // {
+            default = true;
+          };
+        view = mkOption {
+          description = "view for messages";
+          type = str;
+          default = "notify";
+        };
+        view_error = mkOption {
+          description = "view for error messages";
+          type = str;
+          default = "notify";
+        };
+        view_warn = mkOption {
+          description = "view for warnings";
+          type = str;
+          default = "notify";
+        };
+        view_history = mkOption {
+          description = "view for :messages";
+          type = str;
+          default = "messages";
+        };
+        view_search = mkOption {
+          description = "view for search count messages";
+          type = str;
+          default = "virtualtext";
+        };
+      };
+
+      notify = {
+        enabled =
+          mkEnableOption "vim.notify routing"
+          // {
+            default = true;
+          };
+        view = mkOption {
+          description = "view for vim.notify";
+          type = str;
+          default = "notify";
+        };
+      };
+
+      health = {
+        checker =
+          mkEnableOption "health checks"
+          // {
+            default = true;
+          };
+      };
+
       presets = {
         bottom_search = mkBool true "use a classic bottom cmdline for search";
         command_palette = mkBool true "position the cmdline and popupmenu together";


### PR DESCRIPTION
Provides message, notify, and health options to the `noice` plugin.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
