### PR TITLE
languages/tera: add syntax highlighting support for tera templating

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -96,6 +96,7 @@ isMaximal: {
       jinja.enable = false;
       tailwind.enable = false;
       svelte.enable = false;
+      tera.enable = false;
 
       # Nim LSP is broken on Darwin and therefore
       # should be disabled by default. Users may still enable

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -161,6 +161,9 @@
 
 - Added XML syntax highlighting, LSP support and formatting
 
+- Added [tera](https://keats.github.io/tera/) language support (syntax
+  highlighting only).
+
 [vagahbond](https://github.com/vagahbond): [codewindow.nvim]:
 https://github.com/gorbit99/codewindow.nvim
 

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -19,6 +19,7 @@ in {
     ./helm.nix
     ./kotlin.nix
     ./html.nix
+    ./tera.nix
     ./haskell.nix
     ./java.nix
     ./jinja.nix

--- a/modules/plugins/languages/tera.nix
+++ b/modules/plugins/languages/tera.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.types) mkGrammarOption;
+
+  cfg = config.vim.languages.tera;
+in {
+  options.vim.languages.tera = {
+    enable = mkEnableOption "Tera templating language support";
+
+    treesitter = {
+      enable = mkEnableOption "Tera treesitter" // {default = config.vim.languages.enableTreesitter;};
+      package = mkGrammarOption pkgs "tera";
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+  ]);
+}


### PR DESCRIPTION
Adds Syntax highlighting support for the tera language: <https://keats.github.io/tera/>
As of right now, there doesn't seem to be a formmatter or lsp specificly available for tera.

a jinja2/twig formatter should work fine for most cases, but still are quite off, so im not adding them in this.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
