### PR TITLE
meta: fix CONTRIBUTING.md 404 with absolute links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 ## Preface
 
-[LICENSE]: ../LICENSE
+[LICENSE]: /LICENSE
 
 I am glad you are thinking about contributing to nvf! The project is shaped by
 contributors and user feedback, and all contributions are appreciated.
@@ -30,7 +30,7 @@ personally.
 
 ## Contributing Process
 
-[pull request template]: ./PULL_REQUEST_TEMPLATE.md
+[pull request template]: /.github/PULL_REQUEST_TEMPLATE.md
 
 The contribution process is mostly documented in the [pull request template].
 When you create a pull request, you will find a checklist of items to complete


### PR DESCRIPTION
While looking into how to create a PR for a different issue, I noticed that reading the contribution guide on the repository home page by selecting the "Contributing" tab above the readme area, the relative links in `CONTRIBUTING.md` were not resolved as being relative to the `.github` directory, but rather relative to the repository root.

This PR just changes those links to from relative to absolute paths within the repository. It appears that GitHub properly maps absolute paths to be relative to the repository URL. I guess it could have an impact on mirrors or forks hosted elsewhere than GitHub, but since this relates to a file under the `.github` folder it seems reasonable to focus on it working well on GitHub :smile: 

I tested it both using the "Contributing" tab, and opening `.github/CONTRIBUTING.md` directly, and this way works for both.

First PR from me, it seems most of the contribution guidelines naturally target actual functionality, so I didn't check too many boxes below. Let me know if I missed anything!

Below is a screenshot of the issue:

<img width="920" height="880" alt="nvf-pr-contributing-404" src="https://github.com/user-attachments/assets/10a67ed2-86da-4fa9-9cfc-4e55c140d35e" />


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
