### PR TITLE
bufferline.nvim: fix hover behavior

### DIFF
--- a/docs/manual/release-notes.md
+++ b/docs/manual/release-notes.md
@@ -12,4 +12,5 @@ release-notes/rl-0.5.md
 release-notes/rl-0.6.md
 release-notes/rl-0.7.md
 release-notes/rl-0.8.md
+release-notes/rl-0.9.md
 ```

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -1,0 +1,8 @@
+# Release 0.9 {#sec-release-0-9}
+
+## Changelog {#sec-release-0-9-changelog}
+
+
+[suimong](https://github.com/suimong):
+
+- Fix `vim.tabline.nvimBufferline` where `setupOpts.options.hover` requires `vim.opt.mousemoveevent` to be set.

--- a/modules/plugins/tabline/nvim-bufferline/config.nix
+++ b/modules/plugins/tabline/nvim-bufferline/config.nix
@@ -24,15 +24,33 @@ in {
       # Recommended by upstream, so enabled here.
       visuals.nvim-web-devicons.enable = true;
 
+      # See `:help bufferline-hover-events`
+      options = mkIf cfg.setupOpts.options.hover.enabled {
+        mousemoveevent = true;
+      };
+
       maps.normal = mkMerge [
-        (mkLuaBinding cfg.mappings.closeCurrent "require(\"bufdelete\").bufdelete" mappings.closeCurrent.description)
+        (
+          mkLuaBinding cfg.mappings.closeCurrent "require(\"bufdelete\").bufdelete"
+          mappings.closeCurrent.description
+        )
         (mkBinding cfg.mappings.cycleNext ":BufferLineCycleNext<CR>" mappings.cycleNext.description)
         (mkBinding cfg.mappings.cycleNext ":BufferLineCycleNext<CR>" mappings.cycleNext.description)
         (mkBinding cfg.mappings.cyclePrevious ":BufferLineCyclePrev<CR>" mappings.cyclePrevious.description)
         (mkBinding cfg.mappings.pick ":BufferLinePick<CR>" mappings.pick.description)
-        (mkBinding cfg.mappings.sortByExtension ":BufferLineSortByExtension<CR>" mappings.sortByExtension.description)
-        (mkBinding cfg.mappings.sortByDirectory ":BufferLineSortByDirectory<CR>" mappings.sortByDirectory.description)
-        (mkLuaBinding cfg.mappings.sortById "function() require(\"bufferline\").sort_buffers_by(function (buf_a, buf_b) return buf_a.id < buf_b.id end) end" mappings.sortById.description)
+        (
+          mkBinding cfg.mappings.sortByExtension ":BufferLineSortByExtension<CR>"
+          mappings.sortByExtension.description
+        )
+        (
+          mkBinding cfg.mappings.sortByDirectory ":BufferLineSortByDirectory<CR>"
+          mappings.sortByDirectory.description
+        )
+        (
+          mkLuaBinding cfg.mappings.sortById
+          "function() require(\"bufferline\").sort_buffers_by(function (buf_a, buf_b) return buf_a.id < buf_b.id end) end"
+          mappings.sortById.description
+        )
         (mkBinding cfg.mappings.moveNext ":BufferLineMoveNext<CR>" mappings.moveNext.description)
         (mkBinding cfg.mappings.movePrevious ":BufferLineMovePrev<CR>" mappings.movePrevious.description)
       ];


### PR DESCRIPTION
Enable `mousemoveevent` vim option if `setupOpts.options.hover` is enabled, as required by the plugin.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
