### PR TITLE
treesitter: migrate to the new api

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -4,12 +4,8 @@
 
 - Nixpkgs has merged a fully incompatible rewrite of
   `vimPlugins.nvim-treesitter`. Namely, it changes from the frozen `master`
-  branch to the new main branch. This change also affects how grammars are
-  built, and forces us to change a few things around.
-  - We must now use `"nvim-treesitter".setup` over the old `.configs`.
-    Additionally, built grammars **no longer include queries by default**,
-    therefore queries not managed by nvf will lack their respective syntax
-    highlighting capabilities.
+  branch to the new main branch. This change removes incremental selections, so
+  it is no longer available.
 
 ## Changelog {#sec-release-0-9-changelog}
 

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -308,5 +308,39 @@ in {
     ])
     # Migrated via batchRenameOptions. Further batch renames must be below this line.
     renamedVimOpts
+
+    # 2026-01-06
+    [
+      (mkRemovedOptionModule ["vim" "treesitter" "highlight" "disable"] ''
+        Treesitter highlighting is now handled by Neovim natively, and it does not have a disable option.
+      '')
+      (mkRemovedOptionModule ["vim" "treesitter" "highlight" "additionalVimRegexHighlighting"] ''
+        Treesitter highlighting is now handled by Neovim natively, and it does not have a additionalVimRegexHighlighting option.
+      '')
+      (mkRemovedOptionModule ["vim" "treesitter" "indent" "disable"] ''
+        Treesitter indentation is now handled differently, and it does not have a disable option.
+      '')
+      (mkRemovedOptionModule ["vim" "treesitter" "incrementalSelection" "enable"] ''
+        Incremental selection configuration has been removed from nvim-treesitter.
+      '')
+      (mkRemovedOptionModule ["vim" "treesitter" "incrementalSelection" "disable"] ''
+        Incremental selection configuration has been removed from nvim-treesitter.
+      '')
+      (mkRemovedOptionModule ["vim" "treesitter" "mappings" "incrementalSelection" "init"] ''
+        Incremental selection configuration has been removed from nvim-treesitter.
+      '')
+      (mkRemovedOptionModule ["vim" "treesitter" "mappings" "incrementalSelection" "incrementByNode"] ''
+        Incremental selection configuration has been removed from nvim-treesitter.
+      '')
+      (
+        mkRemovedOptionModule ["vim" "treesitter" "mappings" "incrementalSelection" "incrementByScope"]
+        ''
+          Incremental selection configuration has been removed from nvim-treesitter.
+        ''
+      )
+      (mkRemovedOptionModule ["vim" "treesitter" "mappings" "incrementalSelection" "decrementByNode"] ''
+        Incremental selection configuration has been removed from nvim-treesitter.
+      '')
+    ]
   ];
 }

--- a/modules/plugins/treesitter/config.nix
+++ b/modules/plugins/treesitter/config.nix
@@ -1,19 +1,13 @@
 {
   config,
   lib,
-  options,
   ...
 }: let
-  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.modules) mkIf;
   inherit (lib.lists) optionals;
-  inherit (lib.nvim.binds) mkSetBinding addDescriptionsToMappings;
-  inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.dag) entryBefore entryAfter;
+  inherit (lib.nvim.dag) entryAfter;
 
   cfg = config.vim.treesitter;
-
-  mappingDefinitions = options.vim.treesitter.mappings;
-  mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
   config = mkIf cfg.enable {
     vim = {
@@ -27,68 +21,46 @@ in {
 
       treesitter.grammars = optionals cfg.addDefaultGrammars cfg.defaultGrammars;
 
-      maps = {
-        # HACK: Using mkSetLuaBinding and putting the lua code does not work for some reason: It just selects the whole file.
-        # This works though, and if it ain't broke, don't fix it.
-        normal = mkSetBinding mappings.incrementalSelection.init ":lua require('nvim-treesitter.incremental_selection').init_selection()<CR>";
+      pluginRC.treesitter-autocommands = entryAfter ["basic"] ''
+        vim.api.nvim_create_augroup("nvf_treesitter", { clear = true })
 
-        visualOnly = mkMerge [
-          (mkSetBinding mappings.incrementalSelection.incrementByNode "<cmd>lua require('nvim-treesitter.incremental_selection').node_incremental()<CR>")
-          (mkSetBinding mappings.incrementalSelection.incrementByScope "<cmd>lua require('nvim-treesitter.incremental_selection').scope_incremental()<CR>")
-          (mkSetBinding mappings.incrementalSelection.decrementByNode "<cmd>lua require('nvim-treesitter.incremental_selection').node_decremental()<CR>")
-        ];
-      };
+        ${lib.optionalString cfg.highlight.enable ''
+          -- Enable treesitter highlighting for all filetypes
+          vim.api.nvim_create_autocmd("FileType", {
+            group = "nvf_treesitter",
+            pattern = "*",
+            callback = function()
+              pcall(vim.treesitter.start)
+            end,
+          })
+        ''}
 
-      # For some reason treesitter highlighting does not work on start if this is set before syntax on
-      pluginRC.treesitter-fold = mkIf cfg.fold (entryBefore ["basic"] ''
-        -- This is required by treesitter-context to handle folds
-        vim.o.foldmethod = "expr"
-        vim.o.foldexpr = "nvim_treesitter#foldexpr()"
+        ${lib.optionalString cfg.indent.enable ''
+          -- Enable treesitter highlighting for all filetypes
+          vim.api.nvim_create_autocmd("FileType", {
+            group = "nvf_treesitter",
+            pattern = "*",
+            callback = function()
+              vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+            end,
+          })
+        ''}
 
-        -- This is optional, but is set rather as a sane default.
-        -- If unset, opened files will be folded by automatically as
-        -- the files are opened
-        vim.o.foldenable = false
-      '');
-
-      pluginRC.treesitter = entryAfter ["basic"] ''
-        require('nvim-treesitter.config').setup {
-          -- Disable imperative treesitter options that would attempt to fetch
-          -- grammars into the read-only Nix store. To add additional grammars here
-          -- you must use the `config.vim.treesitter.grammars` option.
-          auto_install = false,
-          sync_install = false,
-          ensure_installed = {},
-
-          -- Indentation module for Treesitter
-          indent = {
-            enable = ${toLuaObject cfg.indent.enable},
-            disable = ${toLuaObject cfg.indent.disable},
-          },
-
-          -- Highlight module for Treesitter
-          highlight = {
-            enable = ${toLuaObject cfg.highlight.enable},
-            disable = ${toLuaObject cfg.highlight.disable},
-            additional_vim_regex_highlighting = ${toLuaObject cfg.highlight.additionalVimRegexHighlighting},
-          },
-
-          -- Indentation module for Treesitter
-          -- Keymaps are set to false here as they are
-          -- handled by `vim.maps` entries calling lua
-          -- functions achieving the same functionality.
-          incremental_selection = {
-            enable = ${toLuaObject cfg.incrementalSelection.enable},
-            disable = ${toLuaObject cfg.incrementalSelection.disable},
-            keymaps = {
-              init_selection = false,
-              node_incremental = false,
-              scope_incremental = false,
-              node_decremental = false,
-
-            },
-          },
-        }
+        ${lib.optionalString cfg.fold ''
+          -- Enable treesitter folding for all filetypes
+          vim.api.nvim_create_autocmd("FileType", {
+            group = "nvf_treesitter",
+            pattern = "*",
+            callback = function()
+              vim.wo[0][0].foldmethod = "expr"
+              vim.wo[0][0].foldexpr = "v:lua.vim.treesitter.foldexpr()"
+              -- This is optional, but is set rather as a sane default.
+              -- If unset, opened files will be folded by automatically as
+              -- the files are opened
+              vim.o.foldenable = false
+            end,
+          })
+        ''}
       '';
     };
   };

--- a/modules/plugins/treesitter/treesitter.nix
+++ b/modules/plugins/treesitter/treesitter.nix
@@ -3,20 +3,11 @@
   lib,
   ...
 }: let
-  inherit (lib.options) mkOption mkEnableOption literalMD literalExpression;
-  inherit (lib.types) listOf package str either bool;
-  inherit (lib.nvim.binds) mkMappingOption;
-  inherit (lib.nvim.types) luaInline;
+  inherit (lib.options) mkOption mkEnableOption literalExpression;
+  inherit (lib.types) listOf package bool;
 in {
   options.vim.treesitter = {
     enable = mkEnableOption "treesitter, also enabled automatically through language options";
-
-    mappings.incrementalSelection = {
-      init = mkMappingOption "Init selection [treesitter]" "gnn";
-      incrementByNode = mkMappingOption "Increment selection by node [treesitter]" "grn";
-      incrementByScope = mkMappingOption "Increment selection by scope [treesitter]" "grc";
-      decrementByNode = mkMappingOption "Decrement selection by node [treesitter]" "grm";
-    };
 
     fold = mkEnableOption "fold with treesitter";
     autotagHtml = mkEnableOption "autoclose and rename html tag";
@@ -25,14 +16,14 @@ in {
       type = listOf package;
       default = [];
       example = literalExpression ''
-        with pkgs.vimPlugins.nvim-treesitter.grammarPlugins; [
+        with pkgs.vimPlugins.nvim-treesitter.parsers; [
           regex
           kdl
         ];
       '';
       description = ''
         List of treesitter grammars to install. For grammars to be installed properly,
-        you must use grammars from `pkgs.vimPlugins.nvim-treesitter.grammarPlugins`.
+        you must use grammars from `pkgs.vimPlugins.nvim-treesitter.parsers` or `pkgs.vimPlugins.nvim-treesitter.grammarPlugins`.
         You can use `pkgs.vimPlugins.nvim-treesitter.allGrammars` to install all grammars.
 
         For languages already supported by nvf, you may use
@@ -56,7 +47,7 @@ in {
       internal = true;
       readOnly = true;
       type = listOf package;
-      default = with pkgs.vimPlugins.nvim-treesitter.grammarPlugins; [c lua vim vimdoc query];
+      default = with pkgs.vimPlugins.nvim-treesitter.parsers; [c lua vim vimdoc query];
       description = ''
         A list of treesitter grammars that will be installed by default
         if treesitter has been enabled and  {option}`vim.treeesitter.addDefaultGrammars`
@@ -73,105 +64,7 @@ in {
       '';
     };
 
-    indent = {
-      enable = mkEnableOption "indentation with treesitter" // {default = true;};
-      disable = mkOption {
-        type = either (listOf str) luaInline;
-        default = [];
-        example = literalExpression ''["c" "rust"]'';
-
-        description = ''
-          List of treesitter grammars to disable indentation for.
-
-          This option can be either a list, in which case it will be
-          converted to a Lua table containing grammars to disable
-          indentation for, or a string containing a **lua function**
-          that will be read as is.
-
-          ::: {.warning}
-          A comma will be added at the end of your function, so you
-          do not need to add it yourself. Doing so will cause in
-          syntax errors within your Neovim configuration.
-          :::
-        '';
-      };
-    };
-
-    highlight = {
-      enable = mkEnableOption "highlighting with treesitter" // {default = true;};
-      disable = mkOption {
-        type = either (listOf str) luaInline;
-        default = [];
-        example = literalMD ''
-          ```lua
-          -- Disable slow treesitter highlight for large files
-          function(lang, buf)
-            local max_filesize = 1000 * 1024 -- 1MB
-            local ok, stats = pcall(vim.uv.fs_stat, vim.api.nvim_buf_get_name(buf))
-            if ok and stats and stats.size > max_filesize then
-                return true
-            end
-          end
-          ```
-        '';
-
-        description = ''
-          List of treesitter grammars to disable highlighting for.
-
-          This option can be either a list, in which case it will be
-          converted to a Lua table containing grammars to disable
-          highlighting for, or a string containing a **lua function**
-          that will be read as is.
-
-          ::: {.warning}
-          A comma will be added at the end of your function, so you
-          do not need to add it yourself. Doing so will cause in
-          syntax errors within your Neovim configuration.
-          :::
-        '';
-      };
-
-      additionalVimRegexHighlighting = mkOption {
-        type = either bool (listOf str);
-        default = false;
-        description = ''
-          Takes either a boolean or a list of languages.
-
-          Setting this to true will run `:h syntax` and tree-sitter at the same time.
-          You may this to `true` if you depend on 'syntax' being enabled (like for
-          indentation).
-
-          ::: {.note}
-          Using this option may slow down your editor, and you may see some duplicate
-          highlights.
-          :::
-        '';
-      };
-    };
-
-    incrementalSelection = {
-      enable = mkEnableOption "incremental selection with treesitter" // {default = true;};
-      disable = mkOption {
-        type = either (listOf str) luaInline;
-        default = [];
-        example = literalExpression ''["c" "rust" ]'';
-
-        description = ''
-          List of treesitter grammars to disable incremental selection
-          for.
-
-          This option can be either a list, in which case it will be
-          converted to a Lua table containing grammars to disable
-          indentation for, or a string containing a **lua function**
-          that will be read as is.
-
-          ::: {.warning}
-          A comma will be added at the end of your function, so you
-          do not need to add it yourself. Doing so will cause in
-          syntax errors within your Neovim configuration.
-          :::
-        '';
-      };
-    };
+    indent = {enable = mkEnableOption "indentation with treesitter" // {default = true;};};
+    highlight = {enable = mkEnableOption "highlighting with treesitter" // {default = true;};};
   };
 }


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

I migrated the nvim-treesitter to work with the new API (correctly), it removes incremental selection, as it is no longer supported, and some other options. I have also fixed the changelog, that was misleading, because queries are installed via withPlugins, if installed via `pkgs.vimPlugins.nvim-treesitter.grammarPlugins` or `pkgs.vimPlugins.nvim-treesitter.parsers`.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [x] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
