### PR TITLE
languages/python: expand LSPs

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -131,3 +131,7 @@
 - Added [rumdl](https://github.com/rvben/rumdl) support to `languages.markdown`
 
 - Added [sqruff](https://github.com/quarylabs/sqruff) support to `languages.sql`
+
+[Machshev](https://github.com/machshev):
+
+- Added `ruff` and `ty` LSP support for Python under `programs.python`.

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -126,6 +126,34 @@
         ".git"
       ];
     };
+
+    ruff = {
+      enable = true;
+      cmd = [(getExe pkgs.ruff) "server"];
+      filetypes = ["python"];
+      root_markers = [
+        "pyproject.toml"
+        "setup.py"
+        "setup.cfg"
+        "requirements.txt"
+        "Pipfile"
+        ".git"
+      ];
+    };
+
+    ty = {
+      enable = true;
+      cmd = [(getExe pkgs.ty) "server"];
+      filetypes = ["python"];
+      root_markers = [
+        "pyproject.toml"
+        "setup.py"
+        "setup.cfg"
+        "requirements.txt"
+        "Pipfile"
+        ".git"
+      ];
+    };
   };
 
   defaultFormat = ["black"];


### PR DESCRIPTION
Now that the new LSP API is available:

- `ruff`: add support for the LSP as well as the existing formatter support
- `ty`: new type checking from astral (promising new type checker)

## Sanity Checking

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_ - there are 13 errors but I don't think I've introduced any of them?
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
