### PR TITLE
Add ty language server for python

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -22,8 +22,8 @@
 
   Some other settings and commands are now deprecated but are still supported.
 
-  - The `setupOpts.mappings` options were also removed. Use the built-in
-    Neovim settings (nvf's {option}`vim.keymaps`)
+  - The `setupOpts.mappings` options were also removed. Use the built-in Neovim
+    settings (nvf's {option}`vim.keymaps`)
 
 ## Changelog {#sec-release-0-9-changelog}
 
@@ -57,7 +57,8 @@
 
 [jtliang24](https://github.com/jtliang24):
 
-- Updated nix language plugin to use pkgs.nixfmt instead of pkgs.nixfmt-rfc-style
+- Updated nix language plugin to use pkgs.nixfmt instead of
+  pkgs.nixfmt-rfc-style
 
 [alfarel](https://github.com/alfarelcynthesis):
 
@@ -112,3 +113,9 @@
     {command}`:healthcheck` doesn't know that.
   - Remove [which-key.nvim] `<leader>o` `+Notes` description which did not
     actually correspond to any keybinds.
+
+[Clearbloo](https://github.com/Clearbloo):
+
+[ty](https://github.com/astral-sh/ty)
+
+- Add the ty lsp for python

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -126,6 +126,20 @@
         ".git"
       ];
     };
+    ty = {
+      enable = true;
+      cmd = [(getExe pkgs.ty) "server"];
+      filetypes = ["python"];
+      root_markers = [
+        "pyproject.toml"
+        "ty.toml"
+        "setup.py"
+        "setup.cfg"
+        "requirements.txt"
+        "Pipfile"
+        ".git"
+      ];
+    };
   };
 
   defaultFormat = ["black"];


### PR DESCRIPTION
Add [ty](https://github.com/astral-sh/ty) as an option for python language servers
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

Related to #1285 

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
