### PR TITLE
languages/markdown: support rumdl

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -124,3 +124,7 @@
     {command}`:healthcheck` doesn't know that.
   - Remove [which-key.nvim] `<leader>o` `+Notes` description which did not
     actually correspond to any keybinds.
+
+[pyrox0](https://github.com/pyrox0):
+
+- Added [rumdl](https://github.com/rvben/rumdl) support to `languages.markdown`

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -31,6 +31,13 @@
       filetypes = ["markdown"];
       root_markers = [".git" ".obsidian" ".moxide.toml"];
     };
+
+    rumdl = {
+      enable = true;
+      cmd = [(getExe pkgs.rumdl) "server"];
+      filetypes = ["markdown"];
+      root_markers = [".git" ".rumdl.toml" "rumdl.toml" ".config/rumdl.toml" "pyproject.toml"];
+    };
   };
 
   defaultFormat = ["deno_fmt"];
@@ -42,6 +49,9 @@
     deno_fmt = {
       command = getExe pkgs.deno;
     };
+    rumdl = {
+      command = getExe pkgs.rumdl;
+    };
     prettierd = {
       command = getExe pkgs.prettierd;
     };
@@ -50,6 +60,9 @@
   diagnosticsProviders = {
     markdownlint-cli2 = {
       package = pkgs.markdownlint-cli2;
+    };
+    rumdl = {
+      package = pkgs.rumdl;
     };
   };
 in {


### PR DESCRIPTION
Adds support for [rumdl](https://github.com/rvben/rumdl) to the markdown module, as a language server, formatter, and linter, as it supports all 3 modes.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
