### PR TITLE
languages/sql: support sqruff

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -128,3 +128,5 @@
 [pyrox0](https://github.com/pyrox0):
 
 - Added [rumdl](https://github.com/rvben/rumdl) support to `languages.markdown`
+
+- Added [sqruff](https://github.com/quarylabs/sqruff) support to `languages.sql`

--- a/modules/plugins/languages/sql.nix
+++ b/modules/plugins/languages/sql.nix
@@ -15,6 +15,7 @@
 
   cfg = config.vim.languages.sql;
   sqlfluffDefault = pkgs.sqlfluff;
+  sqruffDefault = pkgs.sqruff;
 
   defaultServers = ["sqls"];
   servers = {
@@ -39,6 +40,10 @@
       command = getExe sqlfluffDefault;
       append_args = ["--dialect=${cfg.dialect}"];
     };
+    sqruff = {
+      command = getExe sqruffDefault;
+      append_args = ["--dialect=${cfg.dialect}"];
+    };
   };
 
   defaultDiagnosticsProvider = ["sqlfluff"];
@@ -50,6 +55,13 @@
         args = ["lint" "--format=json" "--dialect=${cfg.dialect}"];
       };
     };
+    sqruff = {
+      package = sqruffDefault;
+      config = {
+        cmd = getExe sqruffDefault;
+        args = ["lint" "--format=json" "--dialect=${cfg.dialect}" "-"];
+      };
+    };
   };
 in {
   options.vim.languages.sql = {
@@ -58,7 +70,7 @@ in {
     dialect = mkOption {
       type = str;
       default = "ansi";
-      description = "SQL dialect for sqlfluff (if used)";
+      description = "SQL dialect for formatters and diagnostics (if used)";
     };
 
     treesitter = {


### PR DESCRIPTION
Adds support for https://github.com/quarylabs/sqruff to `languages.sql` as a formatter and diagnostics provider

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
