### PR TITLE
toml: init language plugin

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -71,6 +71,7 @@ isMaximal: {
         enable = isMaximal;
         extensions.crates-nvim.enable = isMaximal;
       };
+      toml.enable = isMaximal;
 
       # Language modules that are not as common.
       assembly.enable = false;

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -134,6 +134,10 @@
 
 - Added [Pyrefly](https://pyrefly.org/) support to `languages.python`
 
+- Added TOML support via {option}`languages.toml` and the
+  [Tombi](https://tombi-toml.github.io/tombi/) language server, linter, and
+  formatter.
+
 [Machshev](https://github.com/machshev):
 
 - Added `ruff` and `ty` LSP support for Python under `programs.python`.

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -38,6 +38,7 @@ in {
     ./svelte.nix
     ./tailwind.nix
     ./terraform.nix
+    ./toml.nix
     ./ts.nix
     ./typst.nix
     ./zig.nix

--- a/modules/plugins/languages/toml.nix
+++ b/modules/plugins/languages/toml.nix
@@ -1,0 +1,151 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) bool enum;
+  inherit (lib.nvim.types) diagnostics mkGrammarOption deprecatedSingleOrListOf;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+
+  cfg = config.vim.languages.toml;
+  defaultServers = ["tombi"];
+  servers = {
+    tombi = {
+      enable = true;
+      cmd = [
+        (getExe pkgs.tombi)
+        "lsp"
+      ];
+      filetypes = ["toml"];
+      root_markers = [
+        "tombi.toml"
+        ".git"
+      ];
+    };
+  };
+
+  defaultFormat = ["tombi"];
+  formats = {
+    tombi = {
+      command = getExe pkgs.tombi;
+      args = [
+        "format"
+        "--stdin-filepath"
+        "$FILENAME"
+        "-"
+      ];
+    };
+  };
+  defaultDiagnosticsProvider = ["tombi"];
+  diagnosticsProviders = {
+    tombi = {
+      package = pkgs.tombi;
+      args = ["lint"];
+    };
+  };
+in {
+  options.vim.languages.toml = {
+    enable = mkEnableOption "TOML configuration language support";
+
+    treesitter = {
+      enable =
+        mkEnableOption "TOML treesitter"
+        // {
+          default = config.vim.languages.enableTreesitter;
+        };
+      package = mkGrammarOption pkgs "toml";
+    };
+
+    lsp = {
+      enable =
+        mkEnableOption "TOML LSP support"
+        // {
+          default = config.vim.lsp.enable;
+        };
+
+      servers = mkOption {
+        description = "TOML LSP server to use";
+        type = deprecatedSingleOrListOf "vim.language.toml.lsp.servers" (enum (attrNames servers));
+        default = defaultServers;
+      };
+    };
+
+    format = {
+      enable =
+        mkEnableOption "TOML formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+        };
+
+      type = mkOption {
+        type = deprecatedSingleOrListOf "vim.language.toml.format.type" (enum (attrNames formats));
+        default = defaultFormat;
+        description = "TOML formatter to use.";
+      };
+    };
+
+    extraDiagnostics = {
+      enable =
+        mkEnableOption "extra TOML diagnostics"
+        // {
+          default = config.vim.languages.enableExtraDiagnostics;
+        };
+      types = diagnostics {
+        langDesc = "TOML";
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [
+        cfg.treesitter.package
+      ];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.servers =
+        mapListToAttrs (n: {
+          name = n;
+          value = servers.${n};
+        })
+        cfg.lsp.servers;
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts = {
+          formatters_by_ft.toml = cfg.format.type;
+          formatters =
+            mapListToAttrs (name: {
+              inherit name;
+              value = formats.${name};
+            })
+            cfg.format.type;
+        };
+      };
+    })
+
+    (mkIf cfg.extraDiagnostics.enable {
+      vim.diagnostics.nvim-lint = {
+        enable = true;
+        linters_by_ft.toml = cfg.extraDiagnostics.types;
+        linters = mkMerge (
+          map (name: {
+            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
+          })
+          cfg.extraDiagnostics.types
+        );
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
Uses https://tombi-toml.github.io/tombi/ to support the TOML configuration language. Includes LSP, linter, and formatter. This is the same configuration as I use in my own nvf config, just converted to a languages.toml module instead of hardcoded config.

also hi raf

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
