### PR TITLE
add textwidth setting in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = false
+max_line_length = 80
 
 [*.{js,json,nix,yml,yaml,toml}]
 indent_style = space


### PR DESCRIPTION
makes working with our markdown docs less likely to trip CI

hopefully we get less of those trivial CI failures with this
