### PR TITLE
language/make: add treesitter, formatter and diagnostics support

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -92,6 +92,7 @@ isMaximal: {
       ruby.enable = false;
       fsharp.enable = false;
       just.enable = false;
+      make.enable = false;
       qml.enable = false;
       jinja.enable = false;
       tailwind.enable = false;

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -172,6 +172,8 @@
 
 - Added [`golangci-lint`](https://golangci-lint.run/) for more diagnostics.
 
+- Added Makefile support via `languages.make`.
+
 [vagahbond](https://github.com/vagahbond): [codewindow.nvim]:
 https://github.com/gorbit99/codewindow.nvim
 

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -52,6 +52,7 @@ in {
     ./yaml.nix
     ./ruby.nix
     ./just.nix
+    ./make.nix
     ./xml.nix
 
     # This is now a hard deprecation.

--- a/modules/plugins/languages/make.nix
+++ b/modules/plugins/languages/make.nix
@@ -1,0 +1,93 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.meta) getExe;
+  inherit (lib.types) listOf enum;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+
+  cfg = config.vim.languages.make;
+
+  defaultFormat = ["bake"];
+  formats = {
+    bake = {
+      command = "${pkgs.mbake}/bin/mbake";
+    };
+  };
+
+  defaultDiagnosticsProvider = ["checkmake"];
+  diagnosticsProviders = {
+    checkmake = {
+      config = {
+        cmd = getExe pkgs.checkmake;
+      };
+    };
+  };
+in {
+  options.vim.languages.make = {
+    enable = mkEnableOption "Make support";
+
+    treesitter = {
+      enable = mkEnableOption "Make treesitter" // {default = config.vim.languages.enableTreesitter;};
+      package = mkGrammarOption pkgs "make";
+    };
+
+    format = {
+      enable = mkEnableOption "Make formatting" // {default = config.vim.languages.enableFormat;};
+      type = mkOption {
+        description = "make formatter to use";
+        type = listOf (enum (attrNames formats));
+        default = defaultFormat;
+      };
+    };
+
+    extraDiagnostics = {
+      enable = mkEnableOption "extra Make diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+      types = diagnostics {
+        langDesc = "Make";
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter = {
+        enable = true;
+        grammars = [cfg.treesitter.package];
+      };
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts = {
+          formatters_by_ft.make = cfg.format.type;
+          formatters =
+            mapListToAttrs (name: {
+              inherit name;
+              value = formats.${name};
+            })
+            cfg.format.type;
+        };
+      };
+    })
+
+    (mkIf cfg.extraDiagnostics.enable {
+      vim.diagnostics.nvim-lint = {
+        enable = true;
+        linters_by_ft.make = cfg.extraDiagnostics.types;
+        linters =
+          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
+            cfg.extraDiagnostics.types);
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
Adds Makefile support.

`mbake` is only included as formatter and not as diagnostics, as it doesn't provide location information inside its `validate`.
I didn't find an lsp in <https://mason-registry.dev/registry/list?search=language%3Amakefile%20category%3Alsp> so I guess theres prolly isn't one.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
