### PR TITLE
prettier-plugin-astro: update deprecated pnpm attributes

### DIFF
--- a/flake/pkgs/by-name/prettier-plugin-astro/package.nix
+++ b/flake/pkgs/by-name/prettier-plugin-astro/package.nix
@@ -3,6 +3,8 @@
   fetchFromGitHub,
   nodejs,
   pnpm_9,
+  pnpmConfigHook,
+  fetchPnpmDeps,
   pins,
 }: let
   pin = pins.prettier-plugin-astro;
@@ -17,7 +19,8 @@ in
       sha256 = pin.hash;
     };
 
-    pnpmDeps = pnpm_9.fetchDeps {
+    pnpmDeps = fetchPnpmDeps {
+      pnpm = pnpm_9;
       inherit (finalAttrs) pname src;
       fetcherVersion = 2;
       hash = "sha256-K7pIWLkIIbUKDIcysfEtcf/eVMX9ZgyFHdqcuycHCNE=";
@@ -25,7 +28,9 @@ in
 
     nativeBuildInputs = [
       nodejs
-      pnpm_9.configHook
+      (pnpmConfigHook.overrideAttrs {
+        propagatedBuildInputs = [pnpm_9];
+      })
     ];
 
     buildPhase = ''


### PR DESCRIPTION
Building `prettier-plugin-astro` with latest nixpkgs unstable results in the following warnings:
```
trace: evaluation warning: pnpm.configHook: The package attribute is deprecated. Use the top-level pnpmConfigHook attribute instead
trace: evaluation warning: pnpm.fetchDeps: The package attribute is deprecated. Use the top-level fetchPnpmDeps attribute instead
```
Updated the package definition to use the new attributes, and override it to still force `pnpm_9`. This fixes the warnings but functionally the build is exactly the same (as this is what nixpkgs would replace them with internally anyway https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/tools/pnpm/generic.nix#L78)

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
