### PR TITLE
blink-cmp: 1.8.0 -> 1.9.1

### DIFF
--- a/flake/pkgs/by-name/blink-cmp/package.nix
+++ b/flake/pkgs/by-name/blink-cmp/package.nix
@@ -3,17 +3,18 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
+  rust-jemalloc-sys,
   writeShellScriptBin,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "blink-cmp";
-  version = "1.8.0";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "Saghen";
     repo = "blink.cmp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JjlcPj7v9J+v1SDBYIub6jFEslLhZGHmsipV1atUAFo=";
+    hash = "sha256-GgodXdWpQoF2z1g1/WvnSpfuhskw0aMcOoyZM5l66q8=";
   };
 
   forceShare = [
@@ -30,6 +31,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p "$out/target"
     mv "$out/lib" "$out/target/release"
   '';
+
+  # From the blink.cmp flake
+  buildInputs = lib.optionals stdenv.hostPlatform.isAarch64 [rust-jemalloc-sys];
+
+  # NOTE: The only change in frizbee 0.7.0 was nixpkgs incompatible rust semantic changes
+  # Patch just reverts https://github.com/saghen/blink.cmp/commit/cc824ec85b789a54d05241389993c6ab8c040810
+  # Taken from Nixpkgs' blink.cmp derivation, available under the MIT license
+  cargoPatches = [
+    ./patches/0001-pin-frizbee.patch
+  ];
 
   cargoHash = "sha256-Qdt8O7IGj2HySb1jxsv3m33ZxJg96Ckw26oTEEyQjfs=";
 

--- a/flake/pkgs/by-name/blink-cmp/patches/0001-pin-frizbee.patch
+++ b/flake/pkgs/by-name/blink-cmp/patches/0001-pin-frizbee.patch
@@ -1,0 +1,29 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 35bb10e..71c79eb 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -144,9 +144,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+ [[package]]
+ name = "frizbee"
+-version = "0.7.0"
++version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4d024031f1a5bc5f19917baa0b618f1067610e35ba23e9f105653fcb27e74f5c"
++checksum = "c3365720de81dac18e889afa72f5907aa061c975548da68e2400c056ebc94aec"
+ dependencies = [
+  "multiversion",
+  "rayon",
+diff --git a/Cargo.toml b/Cargo.toml
+index 392d1bb..c776c7d 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
+
+ [dependencies]
+ regex = "1.11.2"
+-frizbee = "0.7.0"
++frizbee = "0.6.0"
+ mlua = { version = "0.11.3", features = ["module", "luajit"] }
+ thiserror = "2.0.16"
+ blake3 = "1.8.2"


### PR DESCRIPTION
Bumps the blink.cmp package. Unfortunately this *does not* seem to fix the Treesitter error. Not much I can do there.

[Diff](https://github.com/saghen/blink.cmp/compare/v1.8.0...v1.9.1) | [1.9.0 Changelog](https://github.com/saghen/blink.cmp/blob/main/CHANGELOG.md#190-2025-11-14)
