### PR TITLE
wrapper/build: include pynvim in python3.extraPackages by default

### DIFF
--- a/modules/wrapper/build/config.nix
+++ b/modules/wrapper/build/config.nix
@@ -94,7 +94,7 @@
       nodeJs.enable = config.vim.withNodeJs;
       python3 = {
         enable = config.vim.withPython3;
-        extraPackages = ps: map (flip builtins.getAttr ps) config.vim.python3Packages;
+        extraPackages = ps: (map (flip builtins.getAttr ps) config.vim.python3Packages) ++ [ps.pynvim];
       };
     };
 


### PR DESCRIPTION
this fixes using `Coqtail` and other plugins that require `pynvim`.

it's either this or set the default of `vim.python3Packages` to `pynvim`

tested with
```nix
vim = {
  luaConfigPre = ''
    vim.g.mapleader = " "
  '';
  extraPackages = [pkgs.rocq-core pkgs.coq];
  withPython3 = true;
  startPlugins = [pkgs.vimPlugins.Coqtail];
};
```