### PR TITLE
languages/toml: add taplo (#1386) and make it default instead of tombi

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -45,6 +45,9 @@
   allow valid options. `default` is no longer valid. `inline` and `split` are
   two new valid options.
 
+- Added [taplo](https://taplo.tamasfe.dev/) as the default formatter and lsp for
+  `languages.toml` so we don't default to AI-Slop.
+
 ## Changelog {#sec-release-0-9-changelog}
 
 [taylrfnt](https://github.com/taylrfnt)

--- a/modules/plugins/languages/toml.nix
+++ b/modules/plugins/languages/toml.nix
@@ -8,12 +8,12 @@
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.types) bool enum;
+  inherit (lib.types) enum;
   inherit (lib.nvim.types) diagnostics mkGrammarOption deprecatedSingleOrListOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.toml;
-  defaultServers = ["tombi"];
+  defaultServers = ["taplo"];
   servers = {
     tombi = {
       enable = true;
@@ -27,12 +27,33 @@
         ".git"
       ];
     };
+    taplo = {
+      enable = true;
+      cmd = [
+        (getExe pkgs.taplo)
+        "lsp"
+        "stdio"
+      ];
+      filetypes = ["toml"];
+      root_markers = [
+        ".git"
+      ];
+    };
   };
 
-  defaultFormat = ["tombi"];
+  defaultFormat = ["taplo"];
   formats = {
     tombi = {
       command = getExe pkgs.tombi;
+      args = [
+        "format"
+        "--stdin-filepath"
+        "$FILENAME"
+        "-"
+      ];
+    };
+    taplo = {
+      command = getExe pkgs.taplo;
       args = [
         "format"
         "--stdin-filepath"


### PR DESCRIPTION
Tombi is broke AF and LLM was used in it. lets default to taplo. It looks like the main maintainer of the last few years is going to continue maintaining it. It seems like they plan to move it to a new org. see <https://github.com/tamasfe/taplo/issues/715> for more context.


This will also solve: #1386
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
