### PR TITLE
languages/cmake: use stdio subcommand

### DIFF
--- a/modules/plugins/languages/cmake.nix
+++ b/modules/plugins/languages/cmake.nix
@@ -18,7 +18,7 @@
   servers = {
     neocmakelsp = {
       enable = true;
-      cmd = [(getExe pkgs.neocmakelsp) "--stdio"];
+      cmd = [(getExe pkgs.neocmakelsp) "stdio"];
       filetypes = ["cmake"];
       root_markers = [".gersemirc" ".git" "build" "cmake"];
       capabilities = {


### PR DESCRIPTION
neocmakelsp introduced a breaking change in https://github.com/neocmakelsp/neocmakelsp/commit/0b3ea002a9dd5bc4f2c6d28292e6ea4b0f8680b7 where they moved this flag to a subcommand causing the following error:
```
neocmakelsp-0.10.0/bin/neocmakelsp"	"stderr"	"error: unexpected argument '--stdio' found\n\nUsage: neocmakelsp <COMMAND>\n\nFor more information, try '--help'.\n"
```
the change was introduced in [v0.9.0](https://github.com/neocmakelsp/neocmakelsp/releases/tag/v0.9.0) which seems to have already made it to nix stable, so I don't think this will break anything

tested with fix:

<img width="3804" height="2070" alt="image" src="https://github.com/user-attachments/assets/f10a2ee6-20a5-4611-90ee-2cf7ceedf779" />

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
