### PR TITLE
Allow disabling nvf mappings

### DIFF
--- a/docs/manual/configuring/keybinds.md
+++ b/docs/manual/configuring/keybinds.md
@@ -1,7 +1,9 @@
 # Custom keymaps {#ch-keymaps}
 
-Some plugin modules provide keymap options for your convenience. If a keymap is
-not provided by such module options, you may easily register your own custom
+Some plugin modules provide keymap options for your convenience. These can be
+disabled by toggling {option}`vim.vendoredKeymaps.enable`. It is also possible
+to disable individual keymaps with options by setting them to `null`. If a
+keymap is not provided by a module, you may easily register your own custom
 keymaps via {option}`vim.keymaps`.
 
 ```nix
@@ -22,7 +24,7 @@ keymaps via {option}`vim.keymaps`.
     {
       key = "<leader>k";
       mode = ["n" "x"];
-      
+
       # While `lua` is `true`, `action` is expected to be
       # a valid Lua expression.
       lua = true;

--- a/docs/manual/hacking.md
+++ b/docs/manual/hacking.md
@@ -768,7 +768,7 @@ usage should look something like this:
 # pluginDefinition.nix
 {lib, ...}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.plugin = {
     enable = mkEnableOption "Enable plugin";

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -195,6 +195,7 @@
     {command}`:healthcheck` doesn't know that.
   - Remove [which-key.nvim] `<leader>o` `+Notes` description which did not
     actually correspond to any keybinds.
+- Allow disabling nvf's vendored keymaps by toggling `vendoredKeymaps.enable`.
 
 [pyrox0](https://github.com/pyrox0):
 

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -57,6 +57,7 @@
       "rc"
       "warnings"
       "lazy"
+      "lib"
     ];
 
     # Extra modules, such as deprecation warnings

--- a/modules/neovim/mappings/options.nix
+++ b/modules/neovim/mappings/options.nix
@@ -1,5 +1,5 @@
 {lib, ...}: let
-  inherit (lib.options) mkOption literalMD;
+  inherit (lib.options) mkEnableOption mkOption literalMD;
   inherit (lib.types) either str listOf attrsOf nullOr submodule;
   inherit (lib.nvim.config) mkBool;
 
@@ -57,6 +57,13 @@
     };
 in {
   options.vim = {
+    vendoredKeymaps.enable =
+      mkEnableOption "this project's vendored keymaps by default"
+      // {
+        default = true;
+        example = false;
+      };
+
     keymaps = mkOption {
       type = listOf mapType;
       description = "Custom keybindings.";

--- a/modules/plugins/assistant/chatgpt/chatgpt.nix
+++ b/modules/plugins/assistant/chatgpt/chatgpt.nix
@@ -1,7 +1,11 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.assistant.chatgpt = {
     enable = mkEnableOption "ChatGPT AI assistant. Requires the environment variable OPENAI_API_KEY to be set";

--- a/modules/plugins/assistant/copilot/config.nix
+++ b/modules/plugins/assistant/copilot/config.nix
@@ -21,11 +21,11 @@
   '';
 
   mkLuaKeymap = mode: key: action: desc: opts:
-    opts
-    // {
-      inherit mode key action desc;
-      lua = true;
-    };
+    mkIf (key != null) (opts
+      // {
+        inherit mode key action desc;
+        lua = true;
+      });
 in {
   config = mkIf cfg.enable {
     vim = {

--- a/modules/plugins/assistant/copilot/copilot.nix
+++ b/modules/plugins/assistant/copilot/copilot.nix
@@ -8,6 +8,7 @@
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.types) nullOr str enum float;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 
   cfg = config.vim.assistant.copilot;
 in {
@@ -59,72 +60,19 @@ in {
 
     mappings = {
       panel = {
-        jumpPrev = mkOption {
-          type = nullOr str;
-          default = "[[";
-          description = "Jump to previous suggestion";
-        };
-
-        jumpNext = mkOption {
-          type = nullOr str;
-          default = "]]";
-          description = "Jump to next suggestion";
-        };
-
-        accept = mkOption {
-          type = nullOr str;
-          default = "<CR>";
-          description = "Accept suggestion";
-        };
-
-        refresh = mkOption {
-          type = nullOr str;
-          default = "gr";
-          description = "Refresh suggestions";
-        };
-
-        open = mkOption {
-          type = nullOr str;
-          default = "<M-CR>";
-          description = "Open suggestions";
-        };
+        jumpPrev = mkMappingOption "Jump to previous suggestion" "[[";
+        jumpNext = mkMappingOption "Jump to next suggestion" "]]";
+        accept = mkMappingOption "Accept suggestion" "<CR>";
+        refresh = mkMappingOption "Refresh suggestions" "gr";
+        open = mkMappingOption "Open suggestions" "<M-CR>";
       };
       suggestion = {
-        accept = mkOption {
-          type = nullOr str;
-          default = "<M-l>";
-          description = "Accept suggestion";
-        };
-
-        acceptWord = mkOption {
-          type = nullOr str;
-          default = null;
-          description = "Accept next word";
-        };
-
-        acceptLine = mkOption {
-          type = nullOr str;
-          default = null;
-          description = "Accept next line";
-        };
-
-        prev = mkOption {
-          type = nullOr str;
-          default = "<M-[>";
-          description = "Previous suggestion";
-        };
-
-        next = mkOption {
-          type = nullOr str;
-          default = "<M-]>";
-          description = "Next suggestion";
-        };
-
-        dismiss = mkOption {
-          type = nullOr str;
-          default = "<C-]>";
-          description = "Dismiss suggestion";
-        };
+        accept = mkMappingOption "Accept suggestion" "<M-l>";
+        acceptWord = mkMappingOption "Accept next word" null;
+        acceptLine = mkMappingOption "Accept next line" null;
+        prev = mkMappingOption "Previous suggestion" "<M-[>";
+        next = mkMappingOption "Next suggestion" "<M-]>";
+        dismiss = mkMappingOption "Dismiss suggestion" "<C-]>";
       };
     };
   };

--- a/modules/plugins/assistant/neocodeium/neocodeium.nix
+++ b/modules/plugins/assistant/neocodeium/neocodeium.nix
@@ -1,4 +1,8 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit
     (lib.types)
     nullOr
@@ -11,7 +15,7 @@
     ;
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.assistant.neocodeium = {
     enable = mkEnableOption "NeoCodeium AI completion";

--- a/modules/plugins/assistant/supermaven-nvim/supermaven-nvim.nix
+++ b/modules/plugins/assistant/supermaven-nvim/supermaven-nvim.nix
@@ -1,4 +1,8 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit
     (lib.types)
     nullOr
@@ -10,30 +14,16 @@
     ;
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.assistant.supermaven-nvim = {
     enable = mkEnableOption "Supermaven AI assistant";
 
     setupOpts = mkPluginSetupOption "Supermaven" {
       keymaps = {
-        accept_suggestion = mkOption {
-          type = nullOr str;
-          default = null;
-          example = "<Tab>";
-          description = "The key to accept a suggestion";
-        };
-        clear_suggestion = mkOption {
-          type = nullOr str;
-          default = null;
-          example = "<C-]>";
-          description = "The key to clear a suggestion";
-        };
-        accept_word = mkOption {
-          type = nullOr str;
-          default = null;
-          example = "<C-j>";
-          description = "The key to accept a word";
-        };
+        accept_suggestion = mkMappingOption "The key to accept a suggestion" null // {example = "<Tab>";};
+        clear_suggestion = mkMappingOption "The key to clear a suggestion" null // {example = "<C-]>";};
+        accept_word = mkMappingOption "The key to accept a word" null // {example = "<C-j>";};
       };
       ignore_file = mkOption {
         type = nullOr (attrsOf bool);

--- a/modules/plugins/comments/comment-nvim/comment-nvim.nix
+++ b/modules/plugins/comments/comment-nvim/comment-nvim.nix
@@ -1,7 +1,11 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.comments.comment-nvim = {
     enable = mkEnableOption "smart and powerful comment plugin for neovim comment-nvim";

--- a/modules/plugins/completion/blink-cmp/blink-cmp.nix
+++ b/modules/plugins/completion/blink-cmp/blink-cmp.nix
@@ -1,9 +1,13 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption mkOption literalMD;
   inherit (lib.types) bool listOf str either attrsOf submodule enum anything int nullOr;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline pluginType;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.config) mkBool;
+  inherit (config.vim.lib) mkMappingOption;
 
   keymapType = submodule {
     freeformType = attrsOf (listOf (either str luaInline));

--- a/modules/plugins/completion/blink-cmp/config.nix
+++ b/modules/plugins/completion/blink-cmp/config.nix
@@ -5,7 +5,7 @@
 }: let
   inherit (lib.modules) mkIf;
   inherit (lib.strings) optionalString;
-  inherit (lib.attrsets) optionalAttrs;
+  inherit (lib.attrsets) mapAttrs' optionalAttrs;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.attrsets) attrValues filterAttrs mapAttrsToList;
   inherit (lib.lists) map optional optionals elem;
@@ -98,51 +98,57 @@ in {
           preset = "luasnip";
         };
 
-        keymap = {
-          ${mappings.complete} = ["show" "fallback"];
-          ${mappings.close} = ["hide" "fallback"];
-          ${mappings.scrollDocsUp} = ["scroll_documentation_up" "fallback"];
-          ${mappings.scrollDocsDown} = ["scroll_documentation_down" "fallback"];
-          ${mappings.confirm} = ["accept" "fallback"];
+        keymap =
+          mapAttrs' (mapping-name: action: {
+            name = mappings.${mapping-name};
+            value = action;
+          }) (filterAttrs (mapping-name: _action: mappings.${mapping-name} != null) {
+            complete = ["show" "fallback"];
+            close = ["hide" "fallback"];
+            scrollDocsUp = ["scroll_documentation_up" "fallback"];
+            scrollDocsDown = ["scroll_documentation_down" "fallback"];
+            confirm = ["accept" "fallback"];
+            next = [
+              "select_next"
+              "snippet_forward"
+              (mkLuaInline
+                # lua
+                ''
+                  function(cmp)
+                    local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+                    has_words_before = col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
 
-          ${mappings.next} = [
-            "select_next"
-            "snippet_forward"
-            (mkLuaInline
-              # lua
-              ''
-                function(cmp)
-                  local line, col = unpack(vim.api.nvim_win_get_cursor(0))
-                  has_words_before = col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
-
-                  if has_words_before then
-                    return cmp.show()
+                    if has_words_before then
+                      return cmp.show()
+                    end
                   end
-                end
-              '')
-            "fallback"
-          ];
-          ${mappings.previous} = [
-            "select_prev"
-            "snippet_backward"
-            "fallback"
-          ];
-        };
+                '')
+              "fallback"
+            ];
+            previous = [
+              "select_prev"
+              "snippet_backward"
+              "fallback"
+            ];
+          });
 
         # cmdline is not enabled by default, we're just providing keymaps in
         # case the user enables them
-        cmdline.keymap = {
-          ${mappings.complete} = ["show" "fallback"];
-          ${mappings.close} = ["hide" "fallback"];
-          ${mappings.scrollDocsUp} = ["scroll_documentation_up" "fallback"];
-          ${mappings.scrollDocsDown} = ["scroll_documentation_down" "fallback"];
-          # NOTE: mappings.confirm is skipped because our default, <CR> would
-          # lead to accidental triggers of blink.accept instead of executing
-          # the cmd
-
-          ${mappings.next} = ["select_next" "show" "fallback"];
-          ${mappings.previous} = ["select_prev" "fallback"];
-        };
+        cmdline.keymap =
+          mapAttrs' (mapping-name: action: {
+            name = mappings.${mapping-name};
+            value = action;
+          }) (filterAttrs (mapping-name: _action: mappings.${mapping-name} != null) {
+            complete = ["show" "fallback"];
+            close = ["hide" "fallback"];
+            scrollDocsUp = ["scroll_documentation_up" "fallback"];
+            scrollDocsDown = ["scroll_documentation_down" "fallback"];
+            # NOTE: mappings.confirm is skipped because our default, <CR> would
+            # lead to accidental triggers of blink.accept instead of executing
+            # the cmd
+            next = ["select_next" "show" "fallback"];
+            previous = ["select_prev" "fallback"];
+          });
       };
     };
   };

--- a/modules/plugins/completion/nvim-cmp/config.nix
+++ b/modules/plugins/completion/nvim-cmp/config.nix
@@ -3,6 +3,7 @@
   config,
   ...
 }: let
+  inherit (lib.attrsets) filterAttrs mapAttrs';
   inherit (lib.modules) mkIf;
   inherit (lib.strings) optionalString;
   inherit (lib.generators) mkLuaInline;
@@ -72,48 +73,53 @@ in {
             formatting.format = cfg.format;
 
             # `cmp` and `luasnip` are defined above, in the `nvim-cmp` section
-            mapping = {
-              ${mappings.complete} = mkLuaInline "cmp.mapping.complete()";
-              ${mappings.close} = mkLuaInline "cmp.mapping.abort()";
-              ${mappings.scrollDocsUp} = mkLuaInline "cmp.mapping.scroll_docs(-4)";
-              ${mappings.scrollDocsDown} = mkLuaInline "cmp.mapping.scroll_docs(4)";
-              ${mappings.confirm} = mkLuaInline "cmp.mapping.confirm({ select = true })";
+            mapping =
+              mapAttrs' (mapping-name: action: {
+                name = mappings.${mapping-name};
+                value = action;
+              }) (filterAttrs (mapping-name: _action: mappings.${mapping-name} != null)
+                {
+                  complete = mkLuaInline "cmp.mapping.complete()";
+                  close = mkLuaInline "cmp.mapping.abort()";
+                  scrollDocsUp = mkLuaInline "cmp.mapping.scroll_docs(-4)";
+                  scrollDocsDown = mkLuaInline "cmp.mapping.scroll_docs(4)";
+                  confirm = mkLuaInline "cmp.mapping.confirm({ select = true })";
 
-              ${mappings.next} = mkLuaInline ''
-                cmp.mapping(function(fallback)
-                  local has_words_before = function()
-                    local line, col = unpack(vim.api.nvim_win_get_cursor(0))
-                    return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
-                  end
+                  next = mkLuaInline ''
+                    cmp.mapping(function(fallback)
+                      local has_words_before = function()
+                        local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+                        return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
+                      end
 
-                  if cmp.visible() then
-                    cmp.select_next_item()
-                    ${optionalString luasnipEnable ''
-                  elseif luasnip.locally_jumpable(1) then
-                    luasnip.jump(1)
-                ''}
-                  elseif has_words_before() then
-                    cmp.complete()
-                  else
-                    fallback()
-                  end
-                end)
-              '';
+                      if cmp.visible() then
+                        cmp.select_next_item()
+                        ${optionalString luasnipEnable ''
+                      elseif luasnip.locally_jumpable(1) then
+                        luasnip.jump(1)
+                    ''}
+                      elseif has_words_before() then
+                        cmp.complete()
+                      else
+                        fallback()
+                      end
+                    end)
+                  '';
 
-              ${mappings.previous} = mkLuaInline ''
-                cmp.mapping(function(fallback)
-                  if cmp.visible() then
-                    cmp.select_prev_item()
-                    ${optionalString luasnipEnable ''
-                  elseif luasnip.locally_jumpable(-1) then
-                    luasnip.jump(-1)
-                ''}
-                  else
-                    fallback()
-                  end
-                end)
-              '';
-            };
+                  previous = mkLuaInline ''
+                    cmp.mapping(function(fallback)
+                      if cmp.visible() then
+                        cmp.select_prev_item()
+                        ${optionalString luasnipEnable ''
+                      elseif luasnip.locally_jumpable(-1) then
+                        luasnip.jump(-1)
+                    ''}
+                      else
+                        fallback()
+                      end
+                    end)
+                  '';
+                });
           };
         };
       };

--- a/modules/plugins/completion/nvim-cmp/nvim-cmp.nix
+++ b/modules/plugins/completion/nvim-cmp/nvim-cmp.nix
@@ -6,9 +6,9 @@
   inherit (lib.options) mkEnableOption mkOption literalMD;
   inherit (lib.types) str attrsOf nullOr either listOf;
   inherit (lib.generators) mkLuaInline;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline mergelessListOf pluginType;
   inherit (lib.nvim.lua) toLuaObject;
+  inherit (config.vim.lib) mkMappingOption;
   inherit (builtins) isString;
 
   cfg = config.vim.autocomplete.nvim-cmp;

--- a/modules/plugins/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/plugins/debugger/nvim-dap/nvim-dap.nix
@@ -1,8 +1,12 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.types) bool attrsOf str;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.debugger.nvim-dap = {
     enable = mkEnableOption "debugging via nvim-dap";

--- a/modules/plugins/filetree/nvimtree/nvimtree.nix
+++ b/modules/plugins/filetree/nvimtree/nvimtree.nix
@@ -1,13 +1,15 @@
 {
+  config,
   pkgs,
   lib,
   ...
 }: let
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.generators) mkLuaInline;
-  inherit (lib.types) nullOr str bool int submodule listOf enum oneOf attrs addCheck;
+  inherit (lib.types) str bool int submodule listOf enum oneOf attrs addCheck;
   inherit (lib.nvim.types) mkPluginSetupOption;
   inherit (lib.nvim.config) batchRenameOptions;
+  inherit (config.vim.lib) mkMappingOption;
 
   migrationTable = {
     disableNetrw = "disable_netrw";
@@ -76,26 +78,10 @@ in {
     enable = mkEnableOption "filetree via nvim-tree.lua";
 
     mappings = {
-      toggle = mkOption {
-        type = nullOr str;
-        default = "<leader>t";
-        description = "Toggle NvimTree";
-      };
-      refresh = mkOption {
-        type = nullOr str;
-        default = "<leader>tr";
-        description = "Refresh NvimTree";
-      };
-      findFile = mkOption {
-        type = nullOr str;
-        default = "<leader>tg";
-        description = "Find file in NvimTree";
-      };
-      focus = mkOption {
-        type = nullOr str;
-        default = "<leader>tf";
-        description = "Focus NvimTree";
-      };
+      toggle = mkMappingOption "Toggle NvimTree" "<leader>t";
+      refresh = mkMappingOption "Refresh NvimTree" "<leader>tr";
+      findFile = mkMappingOption "Find file in NvimTree" "<leader>tg";
+      focus = mkMappingOption "Focus NvimTree" "<leader>tf";
     };
 
     setupOpts = mkPluginSetupOption "Nvim Tree" {

--- a/modules/plugins/git/git-conflict/git-conflict.nix
+++ b/modules/plugins/git/git-conflict/git-conflict.nix
@@ -4,8 +4,8 @@
   ...
 }: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.git.git-conflict = {
     enable = mkEnableOption "git-conflict" // {default = config.vim.git.enable;};

--- a/modules/plugins/git/gitsigns/gitsigns.nix
+++ b/modules/plugins/git/gitsigns/gitsigns.nix
@@ -5,8 +5,8 @@
 }: let
   inherit (lib.options) mkEnableOption;
   inherit (lib.modules) mkRenamedOptionModule;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   imports = [
     (mkRenamedOptionModule ["vim" "git" "gitsigns" "codeActions" "vim" "gitsigns" "codeActions"] ["vim" "git" "gitsigns" "codeActions" "enable"])

--- a/modules/plugins/git/neogit/neogit.nix
+++ b/modules/plugins/git/neogit/neogit.nix
@@ -1,7 +1,11 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.git.neogit = {
     enable = mkEnableOption "An Interactive and powerful Git interface [Neogit]";

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -214,24 +214,31 @@ in {
               on_attach = function(client, bufnr)
                 default_on_attach(client, bufnr)
                 local opts = { noremap=true, silent=true, buffer = bufnr }
-                vim.keymap.set("n", "<localleader>rr", ":RustLsp runnables<CR>", opts)
-                vim.keymap.set("n", "<localleader>rp", ":RustLsp parentModule<CR>", opts)
-                vim.keymap.set("n", "<localleader>rm", ":RustLsp expandMacro<CR>", opts)
-                vim.keymap.set("n", "<localleader>rc", ":RustLsp openCargo", opts)
-                vim.keymap.set("n", "<localleader>rg", ":RustLsp crateGraph x11", opts)
-                ${optionalString cfg.dap.enable ''
+
+                ${optionalString config.vim.vendoredKeymaps.enable ''
+              vim.keymap.set("n", "<localleader>rr", ":RustLsp runnables<CR>", opts)
+              vim.keymap.set("n", "<localleader>rp", ":RustLsp parentModule<CR>", opts)
+              vim.keymap.set("n", "<localleader>rm", ":RustLsp expandMacro<CR>", opts)
+              vim.keymap.set("n", "<localleader>rc", ":RustLsp openCargo", opts)
+              vim.keymap.set("n", "<localleader>rg", ":RustLsp crateGraph x11", opts)
+            ''}
+
+                ${optionalString (cfg.dap.enable && config.vim.vendoredKeymaps.enable) ''
               vim.keymap.set("n", "<localleader>rd", ":RustLsp debuggables<cr>", opts)
+            ''}
+
+                ${optionalString (cfg.dap.enable && config.vim.debugger.nvim-dap.mappings.continue != null) ''
               vim.keymap.set(
-               "n", "${config.vim.debugger.nvim-dap.mappings.continue}",
-               function()
-                 local dap = require("dap")
-                 if dap.status() == "" then
-                   vim.cmd "RustLsp debuggables"
-                 else
-                   dap.continue()
-                 end
-               end,
-               opts
+              "n", "${config.vim.debugger.nvim-dap.mappings.continue}",
+              function()
+                local dap = require("dap")
+                if dap.status() == "" then
+                  vim.cmd "RustLsp debuggables"
+                else
+                  dap.continue()
+                end
+              end,
+              opts
               )
             ''}
               end

--- a/modules/plugins/languages/scala.nix
+++ b/modules/plugins/languages/scala.nix
@@ -6,13 +6,13 @@
 }: let
   inherit (lib.generators) mkLuaInline;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.dag) entryAfter;
   inherit (lib.nvim.lua) toLuaObject;
   inherit (lib.nvim.types) mkGrammarOption luaInline;
   inherit (lib.options) mkOption mkEnableOption mkPackageOption literalExpression;
   inherit (lib.strings) optionalString;
   inherit (lib.types) attrsOf anything bool;
+  inherit (config.vim.lib) mkMappingOption;
 
   listCommandsAction =
     if config.vim.telescope.enable

--- a/modules/plugins/languages/scala.nix
+++ b/modules/plugins/languages/scala.nix
@@ -117,7 +117,9 @@ in {
 
             local attach_metals_keymaps = function(client, bufnr)
               attach_keymaps(client, bufnr)  -- from lsp-setup
+              ${optionalString (cfg.lsp.extraMappings.listCommands != null) ''
               vim.api.nvim_buf_set_keymap(bufnr, 'n', '${cfg.lsp.extraMappings.listCommands}', '<cmd>lua ${listCommandsAction}<CR>', {noremap=true, silent=true, desc='Show all Metals commands'})
+            ''}
             end
 
             metals_config = require('metals').bare_config()

--- a/modules/plugins/languages/typst.nix
+++ b/modules/plugins/languages/typst.nix
@@ -13,8 +13,9 @@
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.lua) toLuaObject;
   inherit (lib.nvim.attrsets) mapListToAttrs;
-  inherit (lib.nvim.binds) mkKeymap mkMappingOption;
+  inherit (lib.nvim.binds) mkKeymap;
   inherit (lib.generators) mkLuaInline;
+  inherit (config.vim.lib) mkMappingOption;
 
   cfg = config.vim.languages.typst;
 

--- a/modules/plugins/lsp/module.nix
+++ b/modules/plugins/lsp/module.nix
@@ -1,6 +1,10 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.lsp = {
     formatOnSave = mkEnableOption "format on save";

--- a/modules/plugins/lsp/module.nix
+++ b/modules/plugins/lsp/module.nix
@@ -14,66 +14,26 @@ in {
     };
 
     mappings = {
-      goToDefinition =
-        mkMappingOption "Go to definition"
-        "<leader>lgd";
-      goToDeclaration =
-        mkMappingOption "Go to declaration"
-        "<leader>lgD";
-      goToType =
-        mkMappingOption "Go to type"
-        "<leader>lgt";
-      listImplementations =
-        mkMappingOption "List implementations"
-        "<leader>lgi";
-      listReferences =
-        mkMappingOption "List references"
-        "<leader>lgr";
-      nextDiagnostic =
-        mkMappingOption "Go to next diagnostic"
-        "<leader>lgn";
-      previousDiagnostic =
-        mkMappingOption "Go to previous diagnostic"
-        "<leader>lgp";
-      openDiagnosticFloat =
-        mkMappingOption "Open diagnostic float"
-        "<leader>le";
-      documentHighlight =
-        mkMappingOption "Document highlight"
-        "<leader>lH";
-      listDocumentSymbols =
-        mkMappingOption "List document symbols"
-        "<leader>lS";
-      addWorkspaceFolder =
-        mkMappingOption "Add workspace folder"
-        "<leader>lwa";
-      removeWorkspaceFolder =
-        mkMappingOption "Remove workspace folder"
-        "<leader>lwr";
-      listWorkspaceFolders =
-        mkMappingOption "List workspace folders"
-        "<leader>lwl";
-      listWorkspaceSymbols =
-        mkMappingOption "List workspace symbols"
-        "<leader>lws";
-      hover =
-        mkMappingOption "Trigger hover"
-        "<leader>lh";
-      signatureHelp =
-        mkMappingOption "Signature help"
-        "<leader>ls";
-      renameSymbol =
-        mkMappingOption "Rename symbol"
-        "<leader>ln";
-      codeAction =
-        mkMappingOption "Code action"
-        "<leader>la";
-      format =
-        mkMappingOption "Format"
-        "<leader>lf";
-      toggleFormatOnSave =
-        mkMappingOption "Toggle format on save"
-        "<leader>ltf";
+      goToDefinition = mkMappingOption "Go to definition" "<leader>lgd";
+      goToDeclaration = mkMappingOption "Go to declaration" "<leader>lgD";
+      goToType = mkMappingOption "Go to type" "<leader>lgt";
+      listImplementations = mkMappingOption "List implementations" "<leader>lgi";
+      listReferences = mkMappingOption "List references" "<leader>lgr";
+      nextDiagnostic = mkMappingOption "Go to next diagnostic" "<leader>lgn";
+      previousDiagnostic = mkMappingOption "Go to previous diagnostic" "<leader>lgp";
+      openDiagnosticFloat = mkMappingOption "Open diagnostic float" "<leader>le";
+      documentHighlight = mkMappingOption "Document highlight" "<leader>lH";
+      listDocumentSymbols = mkMappingOption "List document symbols" "<leader>lS";
+      addWorkspaceFolder = mkMappingOption "Add workspace folder" "<leader>lwa";
+      removeWorkspaceFolder = mkMappingOption "Remove workspace folder" "<leader>lwr";
+      listWorkspaceFolders = mkMappingOption "List workspace folders" "<leader>lwl";
+      listWorkspaceSymbols = mkMappingOption "List workspace symbols" "<leader>lws";
+      hover = mkMappingOption "Trigger hover" "<leader>lh";
+      signatureHelp = mkMappingOption "Signature help" "<leader>ls";
+      renameSymbol = mkMappingOption "Rename symbol" "<leader>ln";
+      codeAction = mkMappingOption "Code action" "<leader>la";
+      format = mkMappingOption "Format" "<leader>lf";
+      toggleFormatOnSave = mkMappingOption "Toggle format on save" "<leader>ltf";
     };
   };
 }

--- a/modules/plugins/lsp/nvim-docs-view/nvim-docs-view.nix
+++ b/modules/plugins/lsp/nvim-docs-view/nvim-docs-view.nix
@@ -1,9 +1,13 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
   inherit (lib.types) enum int;
   inherit (lib.modules) mkRenamedOptionModule;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   imports = let
     renamedSetupOption = oldPath: newPath:

--- a/modules/plugins/lsp/otter/otter.nix
+++ b/modules/plugins/lsp/otter/otter.nix
@@ -1,8 +1,12 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.types) bool str listOf;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.lsp = {
     otter-nvim = {

--- a/modules/plugins/lsp/trouble/trouble.nix
+++ b/modules/plugins/lsp/trouble/trouble.nix
@@ -1,7 +1,11 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.lsp = {
     trouble = {

--- a/modules/plugins/minimap/codewindow/codewindow.nix
+++ b/modules/plugins/minimap/codewindow/codewindow.nix
@@ -1,7 +1,11 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.minimap.codewindow = {
     enable = mkEnableOption "codewindow plugin for minimap view";

--- a/modules/plugins/notes/todo-comments/todo-comments.nix
+++ b/modules/plugins/notes/todo-comments/todo-comments.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   ...
@@ -6,8 +7,8 @@
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) str listOf;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   imports = let
     renamedSetupOption = oldPath: newPath:

--- a/modules/plugins/runner/run-nvim/run-nvim.nix
+++ b/modules/plugins/runner/run-nvim/run-nvim.nix
@@ -1,7 +1,11 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options = {
     vim.runner.run-nvim = {

--- a/modules/plugins/session/nvim-session-manager/nvim-session-manager.nix
+++ b/modules/plugins/session/nvim-session-manager/nvim-session-manager.nix
@@ -1,10 +1,15 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.strings) isString;
   inherit (lib.types) nullOr str bool int enum listOf either;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.types) luaInline mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   imports = let
     renameSetupOpt = oldPath: newPath:
@@ -26,29 +31,10 @@ in {
     enable = mkEnableOption "nvim-session-manager: manage sessions like folders in VSCode";
 
     mappings = {
-      loadSession = mkOption {
-        type = nullOr str;
-        description = "Load session";
-        default = "<leader>sl";
-      };
-
-      deleteSession = mkOption {
-        type = nullOr str;
-        description = "Delete session";
-        default = "<leader>sd";
-      };
-
-      saveCurrentSession = mkOption {
-        type = nullOr str;
-        description = "Save current session";
-        default = "<leader>sc";
-      };
-
-      loadLastSession = mkOption {
-        type = nullOr str;
-        description = "Load last session";
-        default = "<leader>slt";
-      };
+      loadSession = mkMappingOption "Load session" "<leader>sl";
+      deleteSession = mkMappingOption "Delete session" "<leader>sd";
+      saveCurrentSession = mkMappingOption "Save current session" "<leader>sc";
+      loadLastSession = mkMappingOption "Load last session" "<leader>slt";
     };
 
     usePicker = mkOption {

--- a/modules/plugins/tabline/nvim-bufferline/nvim-bufferline.nix
+++ b/modules/plugins/tabline/nvim-bufferline/nvim-bufferline.nix
@@ -6,8 +6,8 @@
   inherit (lib.options) mkOption mkEnableOption literalExpression literalMD;
   inherit (lib.types) enum bool either nullOr str int listOf attrs;
   inherit (lib.generators) mkLuaInline;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.tabline.nvimBufferline = {
     enable = mkEnableOption "neovim bufferline";

--- a/modules/plugins/terminal/toggleterm/config.nix
+++ b/modules/plugins/terminal/toggleterm/config.nix
@@ -54,7 +54,9 @@ in {
             end
           })
 
-          vim.keymap.set('n', ${toLuaObject cfg.lazygit.mappings.open}, function() lazygit:toggle() end, {silent = true, noremap = true, desc = '${lazygitMapDesc}'})
+          ${optionalString (cfg.lazygit.mappings.open != null) ''
+            vim.keymap.set('n', ${toLuaObject cfg.lazygit.mappings.open}, function() lazygit:toggle() end, {silent = true, noremap = true, desc = '${lazygitMapDesc}'})
+          ''}
         '';
       };
     };

--- a/modules/plugins/terminal/toggleterm/toggleterm.nix
+++ b/modules/plugins/terminal/toggleterm/toggleterm.nix
@@ -1,14 +1,15 @@
 {
+  config,
   pkgs,
   lib,
   ...
 }: let
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.types) nullOr str enum bool package either int;
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
   inherit (lib.generators) mkLuaInline;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   imports = [
     (mkRenamedOptionModule ["vim" "terminal" "toggleterm" "direction"] ["vim" "terminal" "toggleterm" "setupOpts" "direction"])

--- a/modules/plugins/terminal/toggleterm/toggleterm.nix
+++ b/modules/plugins/terminal/toggleterm/toggleterm.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.types) nullOr str enum bool package either int;
+  inherit (lib.types) nullOr enum bool package either int;
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
   inherit (lib.generators) mkLuaInline;
@@ -19,11 +19,7 @@ in {
   options.vim.terminal.toggleterm = {
     enable = mkEnableOption "toggleterm as a replacement to built-in terminal command";
     mappings = {
-      open = mkOption {
-        type = nullOr str;
-        description = "The keymapping to open toggleterm";
-        default = "<c-t>";
-      };
+      open = mkMappingOption "Open toggleterm" "<c-t>";
     };
 
     setupOpts = mkPluginSetupOption "ToggleTerm" {

--- a/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
+++ b/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
@@ -7,6 +7,8 @@
   inherit (lib.types) nullOr listOf enum bool str int;
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.nvim.types) mkPluginSetupOption borderType;
+  inherit (config.vim.lib) mkMappingOption;
+
   mkSimpleIconOption = default:
     mkOption {
       inherit default;
@@ -83,167 +85,33 @@ in {
     navbuddy = {
       enable = mkEnableOption "navbuddy LSP helper UI. Enabling this option automatically loads and enables nvim-navic";
       mappings = {
-        close = mkOption {
-          type = str;
-          default = "<esc>";
-          description = "Close and return the cursor to its original location.";
-        };
-
-        nextSibling = mkOption {
-          type = str;
-          default = "j";
-          description = "Navigate to the next sibling node.";
-        };
-
-        previousSibling = mkOption {
-          type = str;
-          default = "k";
-          description = "Navigate to the previous sibling node.";
-        };
-
-        parent = mkOption {
-          type = str;
-          default = "h";
-          description = "Navigate to the parent node.";
-        };
-
-        children = mkOption {
-          type = str;
-          default = "l";
-          description = "Navigate to the child node.";
-        };
-
-        root = mkOption {
-          type = str;
-          default = "0";
-          description = "Navigate to the root node.";
-        };
-
-        visualName = mkOption {
-          type = str;
-          default = "v";
-          description = "Select the name visually.";
-        };
-
-        visualScope = mkOption {
-          type = str;
-          default = "V";
-          description = "Select the scope visually.";
-        };
-
-        yankName = mkOption {
-          type = str;
-          default = "y";
-          description = "Yank the name to system clipboard.";
-        };
-
-        yankScope = mkOption {
-          type = str;
-          default = "Y";
-          description = "Yank the scope to system clipboard.";
-        };
-
-        insertName = mkOption {
-          type = str;
-          default = "i";
-          description = "Insert at the start of name.";
-        };
-
-        insertScope = mkOption {
-          type = str;
-          default = "I";
-          description = "Insert at the start of scope.";
-        };
-
-        appendName = mkOption {
-          type = str;
-          default = "a";
-          description = "Insert at the end of name.";
-        };
-
-        appendScope = mkOption {
-          type = str;
-          default = "A";
-          description = "Insert at the end of scope.";
-        };
-
-        rename = mkOption {
-          type = str;
-          default = "r";
-          description = "Rename the node.";
-        };
-
-        delete = mkOption {
-          type = str;
-          default = "d";
-          description = "Delete the node.";
-        };
-
-        foldCreate = mkOption {
-          type = str;
-          default = "f";
-          description = "Create a new fold of the node.";
-        };
-
-        foldDelete = mkOption {
-          type = str;
-          default = "F";
-          description = "Delete the current fold of the node.";
-        };
-
-        comment = mkOption {
-          type = str;
-          default = "c";
-          description = "Comment the node.";
-        };
-
-        select = mkOption {
-          type = str;
-          default = "<enter>";
-          description = "Goto the node.";
-        };
-
-        moveDown = mkOption {
-          type = str;
-          default = "J";
-          description = "Move the node down.";
-        };
-
-        moveUp = mkOption {
-          type = str;
-          default = "K";
-          description = "Move the node up.";
-        };
-
-        togglePreview = mkOption {
-          type = str;
-          default = "s";
-          description = "Toggle the preview.";
-        };
-
-        vsplit = mkOption {
-          type = str;
-          default = "<C-v>";
-          description = "Open the node in a vertical split.";
-        };
-
-        hsplit = mkOption {
-          type = str;
-          default = "<C-s>";
-          description = "Open the node in a horizontal split.";
-        };
-
-        telescope = mkOption {
-          type = str;
-          default = "t";
-          description = "Start fuzzy finder at the current level.";
-        };
-
-        help = mkOption {
-          type = str;
-          default = "g?";
-          description = "Open the mappings help window.";
-        };
+        close = mkMappingOption "Close and return the cursor to its original location." "<esc>";
+        nextSibling = mkMappingOption "Navigate to the next sibling node." "j";
+        previousSibling = mkMappingOption "Navigate to the previous sibling node." "k";
+        parent = mkMappingOption "Navigate to the parent node." "h";
+        children = mkMappingOption "Navigate to the child node." "l";
+        root = mkMappingOption "Navigate to the root node." "0";
+        visualName = mkMappingOption "Select the name visually." "v";
+        visualScope = mkMappingOption "Select the scope visually." "V";
+        yankName = mkMappingOption "Yank the name to system clipboard." "y";
+        yankScope = mkMappingOption "Yank the scope to system clipboard." "Y";
+        insertName = mkMappingOption "Insert at the start of name." "i";
+        insertScope = mkMappingOption "Insert at the start of scope." "I";
+        appendName = mkMappingOption "Insert at the end of name." "a";
+        appendScope = mkMappingOption "Insert at the end of scope." "A";
+        rename = mkMappingOption "Rename the node." "r";
+        delete = mkMappingOption "Delete the node." "d";
+        foldCreate = mkMappingOption "Create a new fold of the node." "f";
+        foldDelete = mkMappingOption "Delete the current fold of the node." "F";
+        comment = mkMappingOption "Comment the node." "c";
+        select = mkMappingOption "Goto the node." "<enter>";
+        moveDown = mkMappingOption "Move the node down." "J";
+        moveUp = mkMappingOption "Move the node up." "K";
+        togglePreview = mkMappingOption "Toggle the preview." "s";
+        vsplit = mkMappingOption "Open the node in a vertical split." "<C-v>";
+        hsplit = mkMappingOption "Open the node in a horizontal split." "<C-s>";
+        telescope = mkMappingOption "Start fuzzy finder at the current level." "t";
+        help = mkMappingOption "Open the mappings help window." "g?";
       };
 
       setupOpts = mkPluginSetupOption "navbuddy" {

--- a/modules/plugins/ui/breadcrumbs/config.nix
+++ b/modules/plugins/ui/breadcrumbs/config.nix
@@ -3,6 +3,7 @@
   lib,
   ...
 }: let
+  inherit (lib.attrsets) filterAttrs mapAttrs';
   inherit (lib.strings) optionalString;
   inherit (lib.modules) mkIf;
   inherit (lib.lists) optionals;
@@ -30,57 +31,62 @@ in {
       ];
 
     vim.ui.breadcrumbs.navbuddy.setupOpts = {
-      mappings = {
-        ${cfg.navbuddy.mappings.close} = mkLuaInline "actions.close()";
-        ${cfg.navbuddy.mappings.nextSibling} = mkLuaInline "actions.next_sibling()";
-        ${cfg.navbuddy.mappings.previousSibling} = mkLuaInline "actions.previous_sibling()";
-        ${cfg.navbuddy.mappings.parent} = mkLuaInline "actions.parent()";
-        ${cfg.navbuddy.mappings.children} = mkLuaInline "actions.children()";
-        ${cfg.navbuddy.mappings.root} = mkLuaInline "actions.root()";
+      mappings =
+        mapAttrs' (mapping-name: action: {
+          name = cfg.navbuddy.mappings.${mapping-name};
+          value = action;
+        }) (filterAttrs (mapping-name: _action: cfg.navbuddy.mappings.${mapping-name} != null)
+          {
+            close = mkLuaInline "actions.close()";
+            nextSibling = mkLuaInline "actions.next_sibling()";
+            previousSibling = mkLuaInline "actions.previous_sibling()";
+            parent = mkLuaInline "actions.parent()";
+            children = mkLuaInline "actions.children()";
+            root = mkLuaInline "actions.root()";
 
-        ${cfg.navbuddy.mappings.visualName} = mkLuaInline "actions.visual_name()";
-        ${cfg.navbuddy.mappings.visualScope} = mkLuaInline "actions.visual_scope()";
+            visualName = mkLuaInline "actions.visual_name()";
+            visualScope = mkLuaInline "actions.visual_scope()";
 
-        ${cfg.navbuddy.mappings.yankName} = mkLuaInline "actions.yank_name()";
-        ${cfg.navbuddy.mappings.yankScope} = mkLuaInline "actions.yank_scope()";
+            yankName = mkLuaInline "actions.yank_name()";
+            yankScope = mkLuaInline "actions.yank_scope()";
 
-        ${cfg.navbuddy.mappings.insertName} = mkLuaInline "actions.insert_name()";
-        ${cfg.navbuddy.mappings.insertScope} = mkLuaInline "actions.insert_scope()";
+            insertName = mkLuaInline "actions.insert_name()";
+            insertScope = mkLuaInline "actions.insert_scope()";
 
-        ${cfg.navbuddy.mappings.appendName} = mkLuaInline "actions.append_name()";
-        ${cfg.navbuddy.mappings.appendScope} = mkLuaInline "actions.append_scope()";
+            appendName = mkLuaInline "actions.append_name()";
+            appendScope = mkLuaInline "actions.append_scope()";
 
-        ${cfg.navbuddy.mappings.rename} = mkLuaInline "actions.rename()";
+            rename = mkLuaInline "actions.rename()";
 
-        ${cfg.navbuddy.mappings.delete} = mkLuaInline "actions.delete()";
+            delete = mkLuaInline "actions.delete()";
 
-        ${cfg.navbuddy.mappings.foldCreate} = mkLuaInline "actions.fold_create()";
-        ${cfg.navbuddy.mappings.foldDelete} = mkLuaInline "actions.fold_delete()";
+            foldCreate = mkLuaInline "actions.fold_create()";
+            foldDelete = mkLuaInline "actions.fold_delete()";
 
-        ${cfg.navbuddy.mappings.comment} = mkLuaInline "actions.comment()";
+            comment = mkLuaInline "actions.comment()";
 
-        ${cfg.navbuddy.mappings.select} = mkLuaInline "actions.select()";
+            select = mkLuaInline "actions.select()";
 
-        ${cfg.navbuddy.mappings.moveDown} = mkLuaInline "actions.move_down()";
-        ${cfg.navbuddy.mappings.moveUp} = mkLuaInline "actions.move_up()";
+            moveDown = mkLuaInline "actions.move_down()";
+            moveUp = mkLuaInline "actions.move_up()";
 
-        ${cfg.navbuddy.mappings.togglePreview} = mkLuaInline "actions.toggle_preview()";
+            togglePreview = mkLuaInline "actions.toggle_preview()";
 
-        ${cfg.navbuddy.mappings.vsplit} = mkLuaInline "actions.vsplit()";
-        ${cfg.navbuddy.mappings.hsplit} = mkLuaInline "actions.hsplit()";
+            vsplit = mkLuaInline "actions.vsplit()";
+            hsplit = mkLuaInline "actions.hsplit()";
 
-        ${cfg.navbuddy.mappings.telescope} = mkLuaInline ''
-          actions.telescope({
-            layout_strategy = "horizontal",
-            layout_config = {
-              height = 0.60,
-              width = 0.75,
-              prompt_position = "top",
-              preview_width = 0.50
-            },
-          })'';
-        ${cfg.navbuddy.mappings.help} = mkLuaInline "actions.help()";
-      };
+            telescope = mkLuaInline ''
+              actions.telescope({
+                layout_strategy = "horizontal",
+                layout_config = {
+                  height = 0.60,
+                  width = 0.75,
+                  prompt_position = "top",
+                  preview_width = 0.50
+                },
+              })'';
+            help = mkLuaInline "actions.help()";
+          });
     };
 
     vim.pluginRC.breadcrumbs = entryAfter ["lspconfig"] ''

--- a/modules/plugins/utility/ccc/ccc.nix
+++ b/modules/plugins/utility/ccc/ccc.nix
@@ -1,9 +1,13 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) anything attrsOf listOf enum;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
   inherit (lib.generators) mkLuaInline;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.utility.ccc = {
     enable = mkEnableOption "ccc color picker for neovim";

--- a/modules/plugins/utility/gestures/gesture-nvim/gesture-nvim.nix
+++ b/modules/plugins/utility/gestures/gesture-nvim/gesture-nvim.nix
@@ -1,6 +1,10 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.gestures.gesture-nvim = {
     enable = mkEnableOption "gesture-nvim: mouse gestures";

--- a/modules/plugins/utility/harpoon/harpoon.nix
+++ b/modules/plugins/utility/harpoon/harpoon.nix
@@ -1,9 +1,13 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.types) bool;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
   inherit (lib.generators) mkLuaInline;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.navigation.harpoon = {
     mappings = {

--- a/modules/plugins/utility/motion/flash/flash.nix
+++ b/modules/plugins/utility/motion/flash/flash.nix
@@ -1,38 +1,22 @@
-{lib, ...}: let
-  inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.types) nullOr str;
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.utility.motion.flash-nvim = {
     enable = mkEnableOption "enhanced code navigation with flash.nvim";
     setupOpts = mkPluginSetupOption "flash-nvim" {};
 
     mappings = {
-      jump = mkOption {
-        type = nullOr str;
-        default = "s";
-        description = "Jump";
-      };
-      treesitter = mkOption {
-        type = nullOr str;
-        default = "S";
-        description = "Treesitter";
-      };
-      remote = mkOption {
-        type = nullOr str;
-        default = "r";
-        description = "Remote Flash";
-      };
-      treesitter_search = mkOption {
-        type = nullOr str;
-        default = "R";
-        description = "Treesitter Search";
-      };
-      toggle = mkOption {
-        type = nullOr str;
-        default = "<c-s>";
-        description = "Toggle Flash Search";
-      };
+      jump = mkMappingOption "Jump" "s";
+      treesitter = mkMappingOption "Treesitter" "S";
+      remote = mkMappingOption "Remote Flash" "r";
+      treesitter_search = mkMappingOption "Treesitter Search" "R";
+      toggle = mkMappingOption "Toggle Flash Search" "<c-s>";
     };
   };
 }

--- a/modules/plugins/utility/motion/hop/hop.nix
+++ b/modules/plugins/utility/motion/hop/hop.nix
@@ -1,6 +1,10 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.utility.motion.hop = {
     mappings = {

--- a/modules/plugins/utility/motion/leap/leap.nix
+++ b/modules/plugins/utility/motion/leap/leap.nix
@@ -1,36 +1,20 @@
-{lib, ...}: let
-  inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.types) nullOr str;
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.utility.motion.leap = {
     enable = mkEnableOption "leap.nvim plugin (easy motion)";
 
     mappings = {
-      leapForwardTo = mkOption {
-        type = nullOr str;
-        description = "Leap forward to";
-        default = "<leader>ss";
-      };
-      leapBackwardTo = mkOption {
-        type = nullOr str;
-        description = "Leap backward to";
-        default = "<leader>sS";
-      };
-      leapForwardTill = mkOption {
-        type = nullOr str;
-        description = "Leap forward till";
-        default = "<leader>sx";
-      };
-      leapBackwardTill = mkOption {
-        type = nullOr str;
-        description = "Leap backward till";
-        default = "<leader>sX";
-      };
-      leapFromWindow = mkOption {
-        type = nullOr str;
-        description = "Leap from window";
-        default = "gs";
-      };
+      leapForwardTo = mkMappingOption "Leap forward to" "<leader>ss";
+      leapBackwardTo = mkMappingOption "Leap backward to" "<leader>sS";
+      leapForwardTill = mkMappingOption "Leap forward till" "<leader>sx";
+      leapBackwardTill = mkMappingOption "Leap backward till" "<leader>sX";
+      leapFromWindow = mkMappingOption "Leap from window" "gs";
     };
   };
 }

--- a/modules/plugins/utility/outline/aerial-nvim/aerial-nvim.nix
+++ b/modules/plugins/utility/outline/aerial-nvim/aerial-nvim.nix
@@ -1,7 +1,11 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.utility.outline.aerial-nvim = {
     enable = mkEnableOption "Aerial.nvim";

--- a/modules/plugins/utility/preview/glow/glow.nix
+++ b/modules/plugins/utility/preview/glow/glow.nix
@@ -1,7 +1,11 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.options) mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   imports = [
     (mkRenamedOptionModule ["vim" "languages" "markdown" "glow" "enable"] ["vim" "utility" "preview" "glow" "enable"])

--- a/modules/plugins/utility/smart-splits/smart-splits.nix
+++ b/modules/plugins/utility/smart-splits/smart-splits.nix
@@ -1,8 +1,12 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkOption;
   inherit (lib.types) bool;
   inherit (lib.nvim.types) mkPluginSetupOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.utility.smart-splits = {
     enable = mkOption {

--- a/modules/plugins/utility/surround/surround.nix
+++ b/modules/plugins/utility/surround/surround.nix
@@ -3,7 +3,7 @@
   config,
   ...
 }: let
-  inherit (lib.options) mkOption;
+  inherit (lib.options) literalExpression mkOption;
   inherit (lib.types) bool str;
   inherit (lib.nvim.types) mkPluginSetupOption;
 
@@ -64,7 +64,8 @@ in {
 
     useVendoredKeybindings = mkOption {
       type = bool;
-      default = true;
+      default = config.vim.vendoredKeymaps.enable;
+      defaultText = literalExpression "config.vim.vendoredKeymaps.enable";
       description = ''
         Use alternative set of keybindings that avoids conflicts with other popular plugins, e.g. nvim-leap
       '';

--- a/modules/plugins/utility/telescope/telescope.nix
+++ b/modules/plugins/utility/telescope/telescope.nix
@@ -6,8 +6,8 @@
 }: let
   inherit (lib.options) mkOption mkEnableOption literalExpression;
   inherit (lib.types) int str listOf float bool either enum submodule attrsOf anything package;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
+  inherit (config.vim.lib) mkMappingOption;
 
   cfg = config.vim.telescope;
   setupOptions = {

--- a/modules/plugins/utility/yazi-nvim/yazi-nvim.nix
+++ b/modules/plugins/utility/yazi-nvim/yazi-nvim.nix
@@ -1,8 +1,12 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.types) bool;
   inherit (lib.nvim.types) mkPluginSetupOption;
-  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.utility.yazi-nvim = {
     enable = mkEnableOption ''

--- a/modules/plugins/visuals/cellular-automaton/cellular-automaton.nix
+++ b/modules/plugins/visuals/cellular-automaton/cellular-automaton.nix
@@ -1,9 +1,13 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.nvim.types) luaInline;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.generators) mkLuaInline;
+  inherit (config.vim.lib) mkMappingOption;
 in {
   imports = [
     (mkRenamedOptionModule ["vim" "visuals" "cellularAutomaton"] ["vim" "visuals" "cellular-automaton"])

--- a/modules/wrapper/lib/config.nix
+++ b/modules/wrapper/lib/config.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkOption;
+  inherit (lib.types) nullOr str;
+in {
+  config.vim.lib = {
+    mkMappingOption = description: default:
+      mkOption {
+        type = nullOr str;
+        default =
+          if config.vim.vendoredKeymaps.enable
+          then default
+          else null;
+        inherit description;
+      };
+  };
+}

--- a/modules/wrapper/lib/default.nix
+++ b/modules/wrapper/lib/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./options.nix
+  ];
+}

--- a/modules/wrapper/lib/options.nix
+++ b/modules/wrapper/lib/options.nix
@@ -1,0 +1,11 @@
+{lib, ...}: let
+  inherit (lib.options) mkOption;
+  inherit (lib.types) attrsOf raw;
+in {
+  options.vim.lib = mkOption {
+    # The second type should be one without merge semantics and which allows function values.
+    type = attrsOf raw;
+    default = {};
+    internal = true;
+  };
+}


### PR DESCRIPTION
This approach to the problem sources `mkMappingOption` from `config`, since it should reference an option for whether to use the provided default or `null`.

This change would be completely transparent to any current users, but requires enforcing that new plugin contributions use `config.vim.lib.mkMappingOption` instead of the `lib.nvim.binds` version.
If people are using the original `mkMappingOption` in outside projects, it will continue working as before, which is probably the desired behaviour.

- First commit contains the actual implementation.
  - Probably best to focus review time here initially, it's fairly simple.
- Second is mostly script-generated, replaces references to the original `mkMappingOption` with ones to the config-aware one.
- Third is fixes to less-automatable issues related to nullable keymaps.
- Fourth is conversions to `mkMappingOption` for options that should have used it but used to use `mkOption`.

Related discussion: #1043

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Feedback Wanted

- Should the lib options go elsewhere? be named something else?
- Should the config-aware `mkMappingOption` be named separately to reduce confusion?
- Should `useNvfKeymaps` be named something else?
- Should this be mentioned in the setup/other docs?
- [x] Should the option also be used to remove which-key group defaults (#718)?
   - Probably not, based on the comment on the issue.

## Remaining work
 
- [x] Direct testing. Packages build, but I should spend some more time inspecting them in an actual setup.
- [x] Make `surround-nvim` vendored keymaps option default depend on the global setting?
- [x] LS keybinds, does rust still require them to be not null?
- [x] Should the `copilot-lua` `mkLuaKeymap` use `lib.binds.mkLuaBinding`?
   - Updated it to allow nulls, should be fine to leave as is, but might be a good opportunity to update it?
- [x] Check that `.#nix` and `.#maximal` build with `useNvfKeymaps` disabled.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
  - I haven't tested every plugin, but the changes **should** be completely transparent, and I've tested both packages with and without the option enabled, as well as my config.
    This is probably worth testing a bit more thoroughly, if it gets accepted.
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
    - debatable, worth talking about (function as config option)
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
    - isn't breaking
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
     - unrelated errors
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
