### PR TITLE
prettier-plugin-astro: set HOME in build to avoid pnpm hook failure

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -57,6 +57,11 @@
 
 ## Changelog {#sec-release-0-9-changelog}
 
+[midischwarz12](https://github.com/midischwarz12):
+
+- Changed the prettier-plugin-astro build to use `writableTmpDirAsHomeHook` to
+  avoid pnpm hook failures in sandboxed builds.
+
 [taylrfnt](https://github.com/taylrfnt)
 
 - Introduce a `darwinModule` option for Darwin users. The ergonomics of

--- a/flake/pkgs/by-name/prettier-plugin-astro/package.nix
+++ b/flake/pkgs/by-name/prettier-plugin-astro/package.nix
@@ -6,6 +6,7 @@
   pnpmConfigHook,
   fetchPnpmDeps,
   pins,
+  writableTmpDirAsHomeHook,
 }: let
   pin = pins.prettier-plugin-astro;
 in
@@ -28,6 +29,7 @@ in
 
     nativeBuildInputs = [
       nodejs
+      writableTmpDirAsHomeHook
       (pnpmConfigHook.overrideAttrs {
         propagatedBuildInputs = [pnpm_9];
       })


### PR DESCRIPTION
Export `HOME=$TMPDIR` in `preConfigure` so pnpm config doesn’t fail on /homeless-shelter

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
