### PR TITLE
treesitter: make foldenable configurable

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -22,7 +22,6 @@
   ```
 
   Some other settings and commands are now deprecated but are still supported.
-
   - The `setupOpts.mappings` options were also removed. Use the built-in Neovim
     settings (nvf's {option}`vim.keymaps`)
 
@@ -35,7 +34,6 @@
 - "Correct `languages.go.treesitter` to contain all Go file types.
   `languages.go.treesitter.package` is now `languages.go.treesitter.goPackage`.
   New are:
-
   - `languages.go.treesitter.goPackage`.
 
   - `languages.go.treesitter.gomodPackage`.
@@ -70,7 +68,7 @@
   following:
 
   ```shell
-  (class: "nixos") cannot be imported into a module 
+  (class: "nixos") cannot be imported into a module
   evaluation that expects class "darwin".
   ```
 
@@ -165,7 +163,9 @@
       - Mappings are now expected to be set using the built-in Neovim APIs,
         managed by `vim.keymaps` in nvf, instead of `mappings` options.
       - Some option defaults have changed.
+
     - And more.
+
   - Automatically configure an enabled picker in the order mentioned above, if
     any are enabled.
   - Add integration with `snacks.image` for rendering workspace/vault assets.
@@ -317,5 +317,9 @@ https://github.com/gorbit99/codewindow.nvim
 [foobar14](https://github.com/foobar14):
 
 - Fix `vim.formatter.conform-nvim.setupOpts.formatters` type for correct merging
+
+[tlvince](https://github.com/tlvince):
+
+- Added configuration option for `foldenable`
 
 <!-- vim: set textwidth=80: -->

--- a/modules/plugins/treesitter/config.nix
+++ b/modules/plugins/treesitter/config.nix
@@ -6,6 +6,7 @@
   inherit (lib.modules) mkIf;
   inherit (lib.lists) optionals;
   inherit (lib.nvim.dag) entryAfter;
+  inherit (lib.trivial) boolToString;
 
   cfg = config.vim.treesitter;
 in {
@@ -54,10 +55,7 @@ in {
             callback = function()
               vim.wo[0][0].foldmethod = "expr"
               vim.wo[0][0].foldexpr = "v:lua.vim.treesitter.foldexpr()"
-              -- This is optional, but is set rather as a sane default.
-              -- If unset, opened files will be folded by automatically as
-              -- the files are opened
-              vim.o.foldenable = false
+              vim.o.foldenable = ${boolToString cfg.foldByDefault}
             end,
           })
         ''}

--- a/modules/plugins/treesitter/treesitter.nix
+++ b/modules/plugins/treesitter/treesitter.nix
@@ -10,6 +10,7 @@ in {
     enable = mkEnableOption "treesitter, also enabled automatically through language options";
 
     fold = mkEnableOption "fold with treesitter";
+    foldByDefault = mkEnableOption "folding by default when a file is opened";
     autotagHtml = mkEnableOption "autoclose and rename html tag";
 
     grammars = mkOption {


### PR DESCRIPTION
Sometimes it can be useful to fold files by default, e.g. for large JSON files and/or using a modeline. This adds a new config option, defaulting to the existing `false`.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
