### PR TITLE
treesitter: remove foldByDefault

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -29,6 +29,10 @@
   is unlikely to cause any noticeable change in behavior or breakage, it's
   mentioned just in case.
 
+- `vim.treesitter.foldByDefault` is removed. Folding behavior should be
+  controlled via `vim.options.foldenable` directly instead. RIP
+  `vim.treesitter.foldByDefault` 2026-03-19 - 2026-03-19.
+
 [Snoweuph](https://github.com/snoweuph)
 
 - "Correct `languages.go.treesitter` to contain all Go file types.

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -342,5 +342,10 @@ in {
         Incremental selection configuration has been removed from nvim-treesitter.
       '')
     ]
+
+    # 2026-03-19
+    [
+      (mkRenamedOptionModule ["vim" "treesitter" "foldByDefault"] ["vim" "options" "foldenable"])
+    ]
   ];
 }

--- a/modules/plugins/treesitter/config.nix
+++ b/modules/plugins/treesitter/config.nix
@@ -6,7 +6,6 @@
   inherit (lib.modules) mkIf;
   inherit (lib.lists) optionals;
   inherit (lib.nvim.dag) entryAfter;
-  inherit (lib.trivial) boolToString;
 
   cfg = config.vim.treesitter;
 in {
@@ -55,7 +54,6 @@ in {
             callback = function()
               vim.wo[0][0].foldmethod = "expr"
               vim.wo[0][0].foldexpr = "v:lua.vim.treesitter.foldexpr()"
-              vim.o.foldenable = ${boolToString cfg.foldByDefault}
             end,
           })
         ''}

--- a/modules/plugins/treesitter/treesitter.nix
+++ b/modules/plugins/treesitter/treesitter.nix
@@ -10,7 +10,6 @@ in {
     enable = mkEnableOption "treesitter, also enabled automatically through language options";
 
     fold = mkEnableOption "fold with treesitter";
-    foldByDefault = mkEnableOption "folding by default when a file is opened";
     autotagHtml = mkEnableOption "autoclose and rename html tag";
 
     grammars = mkOption {


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

setting vim.o.foldenable (globally) in a FileType event is kind of a bad idea in the first place and shouldn't've existed

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [x] I have added a section in the manual
  - [x] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
