### PR TITLE
languages/latex: add latex support wiht lsp, formatter and highlighting

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -74,6 +74,7 @@ isMaximal: {
       };
       toml.enable = isMaximal;
       xml.enable = isMaximal;
+      tex.enable = isMaximal;
 
       # Language modules that are not as common.
       arduino.enable = false;

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -269,6 +269,9 @@
   [twig-cs-fixer](https://github.com/VincentLanglet/Twig-CS-Fixer) aren't
   packaged for nix.
 
+- Added `languages.tex`. Currently only highlighting, formatting and lsp. No
+  previewing yet.
+
 - Didn't Add
   [`syntax-gaslighting`](https://github.com/NotAShelf/syntax-gaslighting.nvim),
   you're crazy.

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -31,6 +31,7 @@ in {
     ./json.nix
     ./lua.nix
     ./markdown.nix
+    ./tex.nix
     ./nim.nix
     ./vala.nix
     ./nix.nix

--- a/modules/plugins/languages/tex.nix
+++ b/modules/plugins/languages/tex.nix
@@ -1,0 +1,115 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.options) literalExpression mkEnableOption mkOption;
+  inherit (lib.types) bool enum listOf;
+  inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+
+  cfg = config.vim.languages.tex;
+  defaultServers = ["texlab"];
+  servers = {
+    texlab = {
+      enable = true;
+      cmd = [(getExe pkgs.texlab) "run"];
+      filetypes = ["plaintex" "tex" "bib"];
+      root_markers = [".git" ".latexmkrc" "latexmkrc" ".texlabroot" "texlabroot" ".texstudio" "Tectonic.toml"];
+    };
+  };
+
+  defaultFormat = ["tex-fmt"];
+  formats = {
+    tex-fmt = {
+      command = getExe pkgs.tex-fmt;
+    };
+    latexindent = {
+      command = "${pkgs.texlive.withPackages (ps: [ps.latexindent])}/bin/latexindent";
+    };
+  };
+in {
+  options.vim.languages.tex = {
+    enable = mkEnableOption "TeX language support";
+
+    treesitter = {
+      enable = mkOption {
+        type = bool;
+        default = config.vim.languages.enableTreesitter;
+        defaultText = literalExpression "config.vim.languages.enableTreesitter";
+        description = "Enable TeX treesitter";
+      };
+      latexPackage = mkGrammarOption pkgs "latex";
+      bibtexPackage = mkGrammarOption pkgs "bibtex";
+    };
+
+    lsp = {
+      enable =
+        mkEnableOption "TeX LSP support"
+        // {
+          default = config.vim.lsp.enable;
+          defaultText = literalExpression "config.vim.lsp.enable";
+        };
+
+      servers = mkOption {
+        description = "TeX LSP server to use";
+        type = listOf (enum (attrNames servers));
+        default = defaultServers;
+      };
+    };
+
+    format = {
+      enable =
+        mkEnableOption "TeX formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+          defaultText = literalExpression "config.vim.languages.enableFormat";
+        };
+
+      type = mkOption {
+        type = listOf (enum (attrNames formats));
+        default = defaultFormat;
+        description = "TeX formatter to use";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [
+        cfg.treesitter.latexPackage
+        cfg.treesitter.bibtexPackage
+      ];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.servers =
+        mapListToAttrs (n: {
+          name = n;
+          value = servers.${n};
+        })
+        cfg.lsp.servers;
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts = {
+          formatters_by_ft.tex = cfg.format.type;
+          formatters_by_ft.plaintex = cfg.format.type;
+          formatters =
+            mapListToAttrs (name: {
+              inherit name;
+              value = formats.${name};
+            })
+            cfg.format.type;
+        };
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
currently the formatter doesn't  care about `.editorconfig` indent config, but I've opened an MR fixing this upstream in `conform.nvim`: [#862](https://github.com/stevearc/conform.nvim/pull/862)

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
