### PR TITLE
Fix Treesitter, to actually allow nulling grammars, and reapply corrected ASM patches

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -304,6 +304,8 @@
 
 - Added `languages.jq`. Supports highlighting, formatting and lsp.
 
+- Extend `languages.asm` to support more filetypes out of the box.
+
 - Didn't Add
   [`syntax-gaslighting`](https://github.com/NotAShelf/syntax-gaslighting.nvim),
   you're crazy.

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -229,6 +229,9 @@
 
 [Snoweuph](https://github.com/snoweuph)
 
+- Fix `tressiter` to allow `null` in grammar options, so they can be filtered
+  out.
+
 - Added [Selenen](https://github.com/kampfkarren/selene) for more diagnostics in
   `languages.lua`.
 

--- a/modules/plugins/languages/asm.nix
+++ b/modules/plugins/languages/asm.nix
@@ -18,7 +18,7 @@
     asm-lsp = {
       enable = true;
       cmd = [(getExe pkgs.asm-lsp)];
-      filetypes = ["asm" "vmasm"];
+      filetypes = ["asm" "nasm" "masm" "vmasm" "fasm" "tasm" "tiasm" "asm68k" "asm8300"];
       root_markers = [".asm-lsp.toml" ".git"];
     };
   };
@@ -33,7 +33,9 @@ in {
           default = config.vim.languages.enableTreesitter;
           defaultText = literalExpression "config.vim.languages.enableTreesitter";
         };
-      package = mkGrammarOption pkgs "asm";
+      packageASM = mkGrammarOption pkgs "asm";
+      packageNASM = mkGrammarOption pkgs "nasm";
+      packageRpiPicoASM = mkGrammarOption pkgs "pioasm";
     };
 
     lsp = {
@@ -53,7 +55,11 @@ in {
   config = mkIf cfg.enable (mkMerge [
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
-      vim.treesitter.grammars = [cfg.treesitter.package];
+      vim.treesitter.grammars = [
+        cfg.treesitter.packageASM
+        cfg.treesitter.packageNASM
+        cfg.treesitter.packageRpiPicoASM
+      ];
     })
 
     (mkIf cfg.lsp.enable {

--- a/modules/plugins/treesitter/treesitter.nix
+++ b/modules/plugins/treesitter/treesitter.nix
@@ -4,7 +4,7 @@
   ...
 }: let
   inherit (lib.options) mkOption mkEnableOption literalExpression;
-  inherit (lib.types) listOf package bool;
+  inherit (lib.types) listOf nullOr package bool;
 in {
   options.vim.treesitter = {
     enable = mkEnableOption "treesitter, also enabled automatically through language options";
@@ -13,7 +13,7 @@ in {
     autotagHtml = mkEnableOption "autoclose and rename html tag";
 
     grammars = mkOption {
-      type = listOf package;
+      type = listOf (nullOr package);
       default = [];
       example = literalExpression ''
         with pkgs.vimPlugins.nvim-treesitter.grammarPlugins; [


### PR DESCRIPTION
Reaply fixed #1505 and fix treesitter grammars actually being nullable
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
