### PR TITLE
svelte: isolate prettier formatter wiring and fix plugin runtime

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -390,4 +390,10 @@ https://github.com/gorbit99/codewindow.nvim
 
 - Add razor support for `roslyn_ls` and `csharp_ls`
 
+[suiiii](https://github.com/suicide)
+
+- Fix `languages.svelte` formatting to use an isolated Conform formatter id and
+  a wrapped Prettier package, so enabling Svelte support no longer overrides
+  TypeScript formatting or breaks Svelte plugin resolution at runtime.
+
 <!-- vim: set textwidth=80: -->

--- a/flake/pkgs/by-name/prettier-plugin-svelte/package.nix
+++ b/flake/pkgs/by-name/prettier-plugin-svelte/package.nix
@@ -1,6 +1,8 @@
 {
   buildNpmPackage,
   fetchFromGitHub,
+  makeWrapper,
+  nodejs,
   pins,
 }: let
   pin = pins.prettier-plugin-svelte;
@@ -9,6 +11,8 @@ in
     pname = "prettier-plugin-svelte";
     version = pin.version or pin.revision;
 
+    meta.mainProgram = "prettier";
+
     src = fetchFromGitHub {
       inherit (pin.repository) owner repo;
       rev = finalAttrs.version;
@@ -16,4 +20,21 @@ in
     };
 
     npmDepsHash = "sha256-XVyLW0XDCvZCZxu8g1fP7fRfeU3Hz81o5FCi/i4BKQw=";
+
+    nativeBuildInputs = [makeWrapper];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/bin" "$out/lib"
+      cp -r node_modules "$out/lib/"
+      mkdir -p "$out/lib/node_modules/prettier-plugin-svelte"
+      cp -r browser.js index.d.ts package.json plugin.js plugin.js.map "$out/lib/node_modules/prettier-plugin-svelte/"
+
+      makeWrapper "${nodejs}/bin/node" "$out/bin/prettier" \
+        --add-flags "$out/lib/node_modules/prettier/bin/prettier.cjs" \
+        --set NODE_PATH "$out/lib/node_modules"
+
+      runHook postInstall
+    '';
   })

--- a/modules/plugins/languages/svelte.nix
+++ b/modules/plugins/languages/svelte.nix
@@ -8,13 +8,21 @@
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.meta) getExe;
+  inherit (lib.meta) getExe getExe';
   inherit (lib.types) enum coercedTo;
   inherit (lib.nvim.types) mkGrammarOption diagnostics deprecatedSingleOrListOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (lib.generators) mkLuaInline;
 
   cfg = config.vim.languages.svelte;
+
+  formatterNames = {
+    prettier = "prettier_svelte";
+    biome = "biome";
+  };
+
+  mapFormatterName = name: formatterNames.${name};
+  configuredFormatters = map mapFormatterName cfg.format.type;
 
   defaultServers = ["svelte"];
   servers = {
@@ -56,13 +64,12 @@
 
   defaultFormat = ["prettier"];
   formats = let
-    prettierPlugin = inputs.self.packages.${pkgs.stdenv.system}.prettier-plugin-svelte;
-    prettierPluginPath = "${prettierPlugin}/lib/node_modules/prettier-plugin-svelte/plugin.js";
+    prettierWithSvelte = inputs.self.packages.${pkgs.stdenv.system}.prettier-plugin-svelte;
   in {
-    prettier = {
-      command = getExe pkgs.prettier;
+    prettier_svelte = {
+      command = getExe' prettierWithSvelte "prettier";
       options.ft_parsers.svelte = "svelte";
-      prepend_args = ["--plugin=${prettierPluginPath}"];
+      prepend_args = ["--plugin=${prettierWithSvelte}/lib/node_modules/prettier-plugin-svelte/plugin.js"];
     };
 
     biome = {
@@ -98,7 +105,7 @@
       lib.warn
       "vim.languages.svelte.format.type: prettierd is deprecated, use prettier instead"
       "prettier")
-    (enum (attrNames formats)));
+    (enum (attrNames formatterNames)));
 in {
   options.vim.languages.svelte = {
     enable = mkEnableOption "Svelte language support";
@@ -179,13 +186,13 @@ in {
       vim.formatter.conform-nvim = {
         enable = true;
         setupOpts = {
-          formatters_by_ft.svelte = cfg.format.type;
+          formatters_by_ft.svelte = configuredFormatters;
           formatters =
             mapListToAttrs (name: {
               inherit name;
               value = formats.${name};
             })
-            cfg.format.type;
+            configuredFormatters;
         };
       };
     })


### PR DESCRIPTION
I ran into the following error when formatting typescript files while typscript and svelte language support were enabled:

```text
Log file: /home/psy/.local/state/nvf/conform.log
          [error] Require stack:
          [error] - /nix/store/hf3gxlvv5lyy47sfynyr3wx1szx9k13i-prettier-plugin-svelte-v3.5.1/lib/node_modules/prettier-plugin-svelte/plugin.js
          
          2026-04-11 00:50:00[ERROR] Formatter 'prettier' error: [error] Cannot find module 'prettier/plugins/babel'
          [error] Require stack:
          [error] - /nix/store/hf3gxlvv5lyy47sfynyr3wx1szx9k13i-prettier-plugin-svelte-v3.5.1/lib/node_modules/prettier-plugin-svelte/plugin.js
          
          2026-04-11 16:25:55[ERROR] Formatter 'prettier' error: [error] Cannot find module 'prettier/plugins/babel'
          [error] Require stack:
          [error] - /nix/store/hf3gxlvv5lyy47sfynyr3wx1szx9k13i-prettier-plugin-svelte-v3.5.1/lib/node_modules/prettier-plugin-svelte/plugin.js
```

There are actually  2 problems:

- `prettier` is defined twice, once for typescript and once for svelte. the svelte config overrides the typescript one as they share the same name. Thus typescript formatting fails due to svelte related issue
- the prettier package for svelte runs into a runtime issues as it cannot find a module 

This solution maps "prettier" internally to a new "prettier_svelte", separate from the configured typescript prettier instance.

The prettier_svelte package bundles prettier-plugin-svelte into local node_modules

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
