### PR TITLE
treesitter: allow setting of treesitter max_lines to be string for percentage values

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -444,5 +444,7 @@ https://github.com/gorbit99/codewindow.nvim
 - Add `vim.treesitter.indent.excludes` to exclude filetypes from the treesitter
   indentation; e.g. useful for Haskell and PureScript, for which treesitter
   indentation does not work good
+- Allow `vim.treesitter.context.setupOpts.max_lines` to also be given as a
+  string in order to allow percentage values like `"20%"`
 
 <!-- vim: set textwidth=80: -->

--- a/modules/plugins/treesitter/ts-context/context.nix
+++ b/modules/plugins/treesitter/ts-context/context.nix
@@ -1,6 +1,6 @@
 {lib, ...}: let
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.types) int bool str nullOr enum;
+  inherit (lib.types) int bool str nullOr enum either;
   inherit (lib.nvim.types) mkPluginSetupOption;
   inherit (lib.nvim.config) batchRenameOptions;
   migrationTable = {
@@ -26,12 +26,14 @@ in {
 
     setupOpts = mkPluginSetupOption "treesitter-context" {
       max_lines = mkOption {
-        type = int;
+        type = either int str;
         default = 0;
         description = ''
           How many lines the window should span.
 
-          Values >= 0 mean there will be no limit.
+          Can be an absolute line number (given as int) or a percentage (given as string, e.g. "20%").
+
+          Values <= 0 mean there will be no limit.
         '';
       };
 


### PR DESCRIPTION
The `max_lines` setting for `treesitter-context` can not only be absolute int values, but also given as percentages. So the type for `max_lines` should allow `str` as type.

See comment above `max_lines` in `:h nvim-treesitter-context-config`.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
