### PR TITLE
Emmet them all

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -316,6 +316,13 @@
 
 - Added Makefile support via `languages.make`.
 
+- Add `lsp.presets.emmet-ls` as supported LSP to
+  - `languages.jinja`
+  - `languages.liquid`
+  - `languages.tera`
+  - `languages.twig`
+  - `languages.astro`
+
 - Fix `languages.hcl` init, depending on `comment-nvim` by checking if it is
   enabled. Fixes a crash (#1350).
 

--- a/modules/plugins/languages/astro.nix
+++ b/modules/plugins/languages/astro.nix
@@ -17,7 +17,7 @@
   cfg = config.vim.languages.astro;
 
   defaultServers = ["astro-language-server"];
-  servers = ["astro-language-server"];
+  servers = ["astro-language-server" "emmet-ls"];
 
   defaultFormat = ["prettier"];
   formats = let

--- a/modules/plugins/languages/jinja.nix
+++ b/modules/plugins/languages/jinja.nix
@@ -13,7 +13,7 @@
   cfg = config.vim.languages.jinja;
 
   defaultServers = ["jinja-lsp"];
-  servers = ["jinja-lsp"];
+  servers = ["jinja-lsp" "emmet-ls"];
 in {
   options.vim.languages.jinja = {
     enable = mkEnableOption "Jinja template language support";

--- a/modules/plugins/languages/liquid.nix
+++ b/modules/plugins/languages/liquid.nix
@@ -4,11 +4,16 @@
   lib,
   ...
 }: let
-  inherit (lib.options) mkEnableOption literalExpression;
+  inherit (lib) genAttrs;
+  inherit (lib.options) mkEnableOption literalExpression mkOption;
   inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) enum listOf;
   inherit (lib.nvim.types) mkGrammarOption;
 
   cfg = config.vim.languages.liquid;
+
+  defaultServers = [];
+  servers = ["emmet-ls"];
 in {
   options.vim.languages.liquid = {
     enable = mkEnableOption "Liquid templating language support";
@@ -22,6 +27,21 @@ in {
         };
       package = mkGrammarOption pkgs "liquid";
     };
+
+    lsp = {
+      enable =
+        mkEnableOption "Liquid LSP support"
+        // {
+          default = config.vim.lsp.enable;
+          defaultText = literalExpression "config.vim.lsp.enable";
+        };
+      servers = mkOption {
+        description = "Liquid LSP server to use";
+        type = listOf (enum servers);
+        default = defaultServers;
+      };
+    };
+
     # TODO: if curlylint gets packaged for nix, add it.
   };
 
@@ -29,6 +49,15 @@ in {
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
       vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp = {
+        presets = genAttrs cfg.lsp.servers (_: {enable = true;});
+        servers = genAttrs cfg.lsp.servers (_: {
+          filetypes = ["liquid"];
+        });
+      };
     })
   ]);
 }

--- a/modules/plugins/languages/tera.nix
+++ b/modules/plugins/languages/tera.nix
@@ -4,11 +4,16 @@
   lib,
   ...
 }: let
-  inherit (lib.options) mkEnableOption literalExpression;
+  inherit (lib) genAttrs;
+  inherit (lib.options) mkEnableOption literalExpression mkOption;
   inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) enum listOf;
   inherit (lib.nvim.types) mkGrammarOption;
 
   cfg = config.vim.languages.tera;
+
+  defaultServers = [];
+  servers = ["emmet-ls"];
 in {
   options.vim.languages.tera = {
     enable = mkEnableOption "Tera templating language support";
@@ -22,12 +27,35 @@ in {
         };
       package = mkGrammarOption pkgs "tera";
     };
+
+    lsp = {
+      enable =
+        mkEnableOption "Tera LSP support"
+        // {
+          default = config.vim.lsp.enable;
+          defaultText = literalExpression "config.vim.lsp.enable";
+        };
+      servers = mkOption {
+        description = "Tera LSP server to use";
+        type = listOf (enum servers);
+        default = defaultServers;
+      };
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
       vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp = {
+        presets = genAttrs cfg.lsp.servers (_: {enable = true;});
+        servers = genAttrs cfg.lsp.servers (_: {
+          filetypes = ["tera"];
+        });
+      };
     })
   ]);
 }

--- a/modules/plugins/languages/twig.nix
+++ b/modules/plugins/languages/twig.nix
@@ -16,7 +16,7 @@
   cfg = config.vim.languages.twig;
 
   defaultServers = ["twig-language-server"];
-  servers = ["twig-language-server"];
+  servers = ["twig-language-server" "emmet-ls"];
 
   defaultFormat = ["djlint"];
   formats = {


### PR DESCRIPTION
all these templating languages are also commonly used for html, so it is a nice touch to be able to use emmet with them, and clearly advertise so with the nvf docs, and not needing to manualy edit `vim.lsp.servers.emmet-ls.filetype`

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
